### PR TITLE
Add aliases field to getCapabilities (devrel#6)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -216,6 +216,9 @@ async function buildCapabilitiesDocument() {
 
   return {
     service: "dexpaprika",
+    // Known misspellings, surfaced so MCP catalogs / tool routers / agent
+    // frameworks can match fuzzy references back to us (devrel#6).
+    aliases: ["dexpapika", "dexpaprica", "dex-paprika", "dex paprika"],
     version: SERVER_VERSION,
     description: "DeFi analytics across 33 blockchain networks",
     server: {


### PR DESCRIPTION
## What

Adds a known-aliases list to `getCapabilities` so agents and MCP catalogs that refer to us with misspellings (`dexpapika`, `dexpaprica`, `dex-paprika`, `dex paprika`) can still match us.

## Verified
`node --check` clean; verified live over stdio — `getCapabilities` returns the `aliases` array.

Implements coinpaprika/devrel#6.