### PR TITLE
Sync self-host package to hosted worker v2.0.0 (full contract parity)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ CLAUDE.md
 # Working/audit files
 HOSTED-MCP-SPEC.md
 DIFF-REPORT.md
+
+# Local verification harness (not part of the published package)
+probe.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the DexPaprika MCP Server will be documented in this file.
 
+## [2.0.0] - 2026-06-03
+
+Full 1:1 contract parity with the hosted DexPaprika MCP worker (`mcp.dexpaprika.com`) v2.0.0. Only the transport differs (stdio vs HTTP); tools, parameters, aliases, synonym resolution, sort normalization, output schemas, server instructions and version now match the worker.
+
+### Breaking changes
+
+- **Response shape — the `{ data, meta }` wrapper is gone.** Previously every tool wrapped its payload as `{ data: <payload>, meta: { rate_limit, response_time_ms, cached, timestamp } }`. Now each tool returns the upstream payload directly, in two forms: `content[0].text` (the JSON string, for older clients) and `structuredContent` (the same object, validated against the tool's `outputSchema`, MCP 2025-06-18+). The per-request `meta` block (rate-limit counters, response time) is no longer emitted. Consumers that read `response.data` must now read the top level. This is intentional and aligns the self-host build with the worker's wire shape.
+- **Array tools wrap under named keys** in `structuredContent`: `getNetworks` → `{ networks: [...] }`, `getPoolOHLCV` → `{ ohlcv: [...] }`. `getTokenMultiPrices` now returns `{ prices: [{id, chain, price_usd}], missing_tokens: [...] }` — tokens upstream could not price are surfaced in `missing_tokens` instead of being silently dropped.
+- **`rationale` is now required on every read tool** (all tools except `submitFeedback`): a 20-500 char string explaining why the call is made. The self-host build accepts it to satisfy the schema and does not persist it (no analytics sink). `submitFeedback` is the one tool with no `rationale` field — its `goal`/`expected`/`observed` fields serve that purpose.
+- **Minimum SDK bump**: `@modelcontextprotocol/sdk` is now `^1.29.0` (was `^1.4.1`). Tools migrated from the deprecated `server.tool()` signature to `server.registerTool()` with explicit `inputSchema`/`outputSchema`/`annotations`.
+
+### Added
+
+- **Network synonym resolution at the wire layer** — `eth` → `ethereum`, `matic` → `polygon`, `sol` → `solana`, and 30+ more across 35 canonical networks. The rewrite happens at the single fetch chokepoint, so advertised synonyms now actually resolve instead of 404ing. The same map drives `getCapabilities.network_synonyms`.
+- **Canonical sort aliases** — `sort_dir` (canonical) alongside `sort` (legacy), and `sort_by` (canonical) alongside `order_by` (legacy), on `getNetworkDexes`, `getNetworkPools`, `getDexPools`, `getTokenPools`, `getTopTokens`. The two filter tools (`getNetworkPoolsFilter`, `filterNetworkTokens`) gain the legacy `sort`/`order_by` aliases. Canonical wins when both are supplied; the legacy wire param each tool already used is preserved.
+- **`getTokenPools` aliases** — `inversed` (canonical, alias of legacy `reorder`) and `paired_token_address` (canonical, alias of legacy `address`).
+- **`submitFeedback` tool (17th tool)** — low-friction feedback channel with `goal`/`attempted_tools`/`blocked_at`/`expected`/`observed`/`severity`. The self-host build returns a structured ack (`{ ok: true, tracking_id: null, ... }`) rather than persisting; the hosted worker writes to its analytics DB.
+- **Per-tool output schemas** — every tool advertises an `outputSchema` (permissive `.passthrough()` so extra upstream fields don't break strict validators like Cursor / Claude Desktop).
+- **Server `instructions`** — onboarding notes (rationale convention, parameter naming, time formats, output shape) advertised once per session via the initialize result.
+
+### Changed
+
+- `getCapabilities` is now a lean, local-only doc matching the worker: top-level `name`/`aliases`/`server`/`tools_count: 17`/`stats` (35 networks, ~29M tokens, ~31M pools, free, no API key)/`network_synonyms`/`workflows`/`common_pitfalls`/`documentation`/`agent_skills`. The previous sprawling capabilities object (validation rules, rate limits, parameter examples, version history, etc.) was replaced. Stale "33 networks" corrected to 35.
+- `page=0` is coerced to `page=1` in all paginated handlers (1-indexed, backward-compat).
+- The structured error handling (`parseAPIError`) is preserved and still surfaces actionable `code`/`suggestion` payloads.
+
+### Notes
+
+- `filterNetworkTokens` advertises a `results` array in its output schema for parity, but the live API returns its rows under `data` (plus a `query` echo). Both pass through `structuredContent` via the schema's outer passthrough; the documented key is optional so real responses validate.
+
 ## [1.3.0] - 2026-03-19
 
 ### ⚠️ BREAKING CHANGES

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "dexpaprika-mcp",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dexpaprika-mcp",
-      "version": "1.5.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.4.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "node-fetch": "^3.3.2",
         "zod": "^3.24.2"
       },
@@ -17,24 +17,74 @@
         "dexpaprika-mcp": "dist/bin.js"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.6.1.tgz",
-      "integrity": "sha512-oxzMzYCkZHMntzuyerehK3fV6A2Kwh5BD6CGEJSVDU2QNEhfLOptf2X7esQgaHZXHZY0oHmMsOtIDLP71UJXgA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
-        "pkce-challenge": "^4.1.0",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/accepts": {
@@ -50,62 +100,61 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/body-parser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.1.0.tgz",
-      "integrity": "sha512-/hPxh61E+ll0Ujp24Ilm64cykicul1ypfwjVttduAiEdtnJFvLePSrIPk+HMImtNv5270wOGCb1Tns2rybMkoQ==",
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.0",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.5.2",
-        "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
-      "engines": {
-        "node": ">=18"
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/body-parser/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
       "dependencies": {
-        "ms": "^2.1.3"
+        "ajv": "^8.0.0"
       },
-      "engines": {
-        "node": ">=6.0"
+      "peerDependencies": {
+        "ajv": "^8.0.0"
       },
       "peerDependenciesMeta": {
-        "supports-color": {
+        "ajv": {
           "optional": true
         }
       }
     },
-    "node_modules/body-parser/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-      "license": "BSD-3-Clause",
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
-        "node": ">=0.6"
+        "node": ">=18"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/bytes": {
@@ -147,15 +196,16 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
@@ -168,9 +218,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -198,6 +248,20 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -208,12 +272,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -231,16 +295,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/dunder-proto": {
@@ -291,9 +345,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -339,53 +393,56 @@
       }
     },
     "node_modules/express": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.0.1.tgz",
-      "integrity": "sha512-ORF7g6qGnD+YtUG9yx4DFoqCShNMmUKiXuT5oWMHiOvt/4WFbHC6yCwQMTSBMno7AqntNCAzzcnnjowRkTL9eQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.0.1",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
-        "content-type": "~1.0.4",
-        "cookie": "0.7.1",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
-        "debug": "4.3.6",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "^2.0.0",
-        "fresh": "2.0.0",
-        "http-errors": "2.0.0",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
         "merge-descriptors": "^2.0.0",
-        "methods": "~1.1.2",
         "mime-types": "^3.0.0",
-        "on-finished": "2.4.1",
-        "once": "1.4.0",
-        "parseurl": "~1.3.3",
-        "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
-        "range-parser": "~1.2.1",
-        "router": "^2.0.0",
-        "safe-buffer": "5.2.1",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
         "send": "^1.1.0",
-        "serve-static": "^2.1.0",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "type-is": "^2.0.0",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -393,8 +450,30 @@
         "url": "https://github.com/sponsors/express-rate-limit"
       },
       "peerDependencies": {
-        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+        "express": ">= 4.11"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
@@ -420,46 +499,25 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.0.0.tgz",
-      "integrity": "sha512-MX6Zo2adDViYh+GcxxB1dpO43eypOGUOL12rLCOTMQv/DfIbpSJUy4oQIIZhVZkH9e+bZWKMon0XHFEju16tkQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
-        "unpipe": "~1.0.0"
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/finalhandler/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/finalhandler/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/finalhandler/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
@@ -562,9 +620,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -573,32 +631,49 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz",
-      "integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/inherits": {
@@ -606,6 +681,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -621,6 +705,33 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -652,40 +763,35 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mime-db": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.53.0.tgz",
-      "integrity": "sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.0.tgz",
-      "integrity": "sha512-XqoSHeCGjVClAmoGFG3lVFqQFRIrTVw2OH3axRqAcfaw+gHWIfnASS92AV+Rl/mk0MupgZTRHQOjxY6YVnzK5w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
-        "mime-db": "^1.53.0"
+        "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -785,19 +891,29 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pkce-challenge": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-4.1.0.tgz",
-      "integrity": "sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
@@ -817,12 +933,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -841,38 +957,37 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
-    "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/router": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.1.0.tgz",
-      "integrity": "sha512-/m/NSLxeYEgWNtyC+WtNHCF7jbGxOibVWKnn+1Psff4dJGOfoXP+MuC/f2CwSmyiHdOIzYnYFp4W6GxWfekaLA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
       "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "is-promise": "^4.0.0",
         "parseurl": "^1.3.3",
         "path-to-regexp": "^8.0.0"
@@ -881,26 +996,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -908,77 +1003,48 @@
       "license": "MIT"
     },
     "node_modules/send": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.1.0.tgz",
-      "integrity": "sha512-v67WcEouB5GxbTWL/4NeToqcZiAWEq90N888fczVArY8A79J0L4FD7vj5hm3eUMua5EpoQ59wa/oovY6TLvRUA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.5",
-        "destroy": "^1.2.0",
+        "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
-        "fresh": "^0.5.2",
-        "http-errors": "^2.0.0",
-        "mime-types": "^2.1.35",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
         "ms": "^2.1.3",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
+        "statuses": "^2.0.2"
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/send/node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/send/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/send/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
       },
-      "engines": {
-        "node": ">= 0.6"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/serve-static": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.1.0.tgz",
-      "integrity": "sha512-A3We5UfEjG8Z7VkDv6uItWw6HY2bBSBJT1KtVESn6EOoOr2jAxNhxWCLY3jDE2WcuHXByWju74ck3ZgLwL8xmA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "parseurl": "^1.3.3",
-        "send": "^1.0.0"
+        "send": "^1.2.0"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/setprototypeof": {
@@ -986,6 +1052,27 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -1007,13 +1094,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1060,9 +1147,9 @@
       }
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1078,17 +1165,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.0.tgz",
-      "integrity": "sha512-gd0sGezQYCbWSbkZr75mln4YBidWUN60+devscpLF5mtRDUpiaTvKpBNrdaCvel1NdR2k6vclXybU5fBd2i+nw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/unpipe": {
@@ -1098,15 +1202,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/vary": {
@@ -1127,6 +1222,21 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -1140,15 +1250,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.3.tgz",
-      "integrity": "sha512-HIAfWdYIt1sssHfYZFCXp4rU1w2r8hVVXYIlmoa0r0gABLs5di3RCqPU5DDROogVz1pAdYBaz7HK5n9pSUNs3A==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.24.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexpaprika-mcp",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "A Model Context Protocol server for DexPaprika cryptocurrency data with network-specific pool queries",
   "main": "dist/index.js",
   "type": "module",
@@ -29,7 +29,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.4.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "node-fetch": "^3.3.2",
     "zod": "^3.24.2"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,70 +1,150 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import fetch from 'node-fetch';
 import { z } from 'zod';
 
-// Base URL for DexPaprika API
+// ─────────────────────────────────────────────────────────────────────────────
+// DexPaprika MCP — self-host (stdio) build, contract-aligned 1:1 with the hosted
+// v2.0.0 Cloudflare Worker. Only the transport differs (stdio vs HTTP). Tools,
+// params/aliases, synonym resolution, sort normalization, output schemas,
+// instructions and version match the worker.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Base URL for DexPaprika API. DexPaprika is fully free: no API key, no auth header.
 const API_BASE_URL = 'https://api.dexpaprika.com';
 
-// Server version
-const SERVER_VERSION = '1.3.0';
+// Server version — matches the hosted worker.
+const SERVER_VERSION = '2.0.0';
 
-// Error code constants
-const ErrorCodes = {
-  DP400_INVALID_NETWORK: "DP400_INVALID_NETWORK",
-  DP400_TOO_MANY_TOKENS: "DP400_TOO_MANY_TOKENS",
-  DP400_INVALID_ADDRESS: "DP400_INVALID_ADDRESS",
-  DP400_MISSING_REQUIRED: "DP400_MISSING_REQUIRED",
-  DP404_NOT_FOUND: "DP404_NOT_FOUND",
-  DP429_RATE_LIMIT: "DP429_RATE_LIMIT",
+// Server identity (inlined from the worker's server-identity.ts).
+const SERVER_CANONICAL_NAME = 'dexpaprika';
+const SERVER_ALIASES = [
+  'dexpapika',   // dropped r
+  'dexpaprica',  // k -> c
+  'dex-paprika', // hyphenated
+  'dex paprika', // spaced
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Network synonym normalization (ported from src/upstream/network-synonyms.ts).
+//
+// getCapabilities advertises common alternate names agents might try
+// (eth -> ethereum, matic -> polygon, etc.). This module gives a single point of
+// normalization so the synonym promise actually holds at the wire layer.
+//
+// Canonical network id (matches /networks response) -> alternates an agent might
+// try. Lowercase. The canonical id is ALWAYS valid as a passthrough.
+// ─────────────────────────────────────────────────────────────────────────────
+const NETWORK_SYNONYMS = {
+  ethereum: ['ethereum', 'eth', 'mainnet', 'eth_mainnet', 'ethereum_mainnet'],
+  solana: ['solana', 'sol'],
+  bsc: ['bsc', 'binance-smart-chain', 'bnb', 'binance', 'bnb_chain', 'bnb-chain'],
+  polygon: ['polygon', 'matic', 'pol', 'polygon_pos'],
+  arbitrum: ['arbitrum', 'arb', 'arbitrum_one', 'arbitrum-one'],
+  base: ['base', 'base_mainnet'],
+  optimism: ['optimism', 'op', 'optimism_mainnet', 'op_mainnet'],
+  avalanche: ['avalanche', 'avalanche-c', 'avax', 'avalanche_c'],
+  sui: ['sui'],
+  mantle: ['mantle', 'mnt'],
+  flow_evm: ['flow_evm', 'flow-evm', 'flow'],
+  katana: ['katana'],
+  unichain: ['unichain', 'uni'],
+  ronin: ['ronin', 'ron'],
+  x_layer: ['x_layer', 'x-layer', 'xlayer', 'okx_xlayer'],
+  linea: ['linea'],
+  sonic: ['sonic', 's'],
+  cronos: ['cronos', 'cro'],
+  sei: ['sei'],
+  blast: ['blast'],
+  tempo: ['tempo'],
+  aptos: ['aptos', 'apt'],
+  zksync: ['zksync', 'zksync_era', 'zksync-era'],
+  scroll: ['scroll'],
+  tron: ['tron', 'trx'],
+  ton: ['ton'],
+  plasma: ['plasma'],
+  bob_network: ['bob_network', 'bob', 'bob-network'],
+  botanix: ['botanix'],
+  fantom: ['fantom', 'ftm'],
+  celo: ['celo'],
+  monad: ['monad'],
+  megaeth: ['megaeth', 'mega-eth', 'mega_eth'],
+  berachain: ['berachain', 'bera'],
+  hyperevm: ['hyperevm', 'hyper-evm', 'hyper_evm'],
 };
 
-// Structured error response builder
-function buildErrorResponse(code, message, retryable, suggestion, correctedExample, metadata) {
-  const error = {
-    error: {
-      code,
-      message,
-      retryable,
-      suggestion,
+// Reverse map built once at module load: alternate (lowercase) -> canonical.
+const REVERSE_SYNONYM_MAP = (() => {
+  const out = {};
+  for (const [canonical, alternates] of Object.entries(NETWORK_SYNONYMS)) {
+    for (const alt of alternates) {
+      out[alt.toLowerCase()] = canonical;
     }
-  };
-  if (correctedExample) {
-    error.error.corrected_example = correctedExample;
   }
-  if (metadata) {
-    error.error.metadata = metadata;
-  }
+  return out;
+})();
+
+// Map an agent-supplied network identifier to its canonical form. Returns the
+// input unchanged if not in the synonym table — upstream will then 404 as before.
+function normalizeNetwork(input) {
+  if (!input || typeof input !== 'string') return input;
+  return REVERSE_SYNONYM_MAP[input.toLowerCase()] ?? input;
+}
+
+// Rewrite the first /networks/{X}/... segment so X is replaced with its canonical
+// form. Idempotent for already-canonical inputs. No-op if it doesn't match.
+function normalizeNetworkPath(endpoint) {
+  return endpoint.replace(/^\/networks\/([^/?]+)/, (_match, raw) => {
+    const canonical = normalizeNetwork(raw);
+    return `/networks/${canonical}`;
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Structured error handling (kept from the existing package — works on top of
+// the new response shape).
+// ─────────────────────────────────────────────────────────────────────────────
+const ErrorCodes = {
+  DP400_INVALID_NETWORK: 'DP400_INVALID_NETWORK',
+  DP400_TOO_MANY_TOKENS: 'DP400_TOO_MANY_TOKENS',
+  DP400_INVALID_ADDRESS: 'DP400_INVALID_ADDRESS',
+  DP400_MISSING_REQUIRED: 'DP400_MISSING_REQUIRED',
+  DP404_NOT_FOUND: 'DP404_NOT_FOUND',
+  DP429_RATE_LIMIT: 'DP429_RATE_LIMIT',
+};
+
+function buildErrorResponse(code, message, retryable, suggestion, correctedExample, metadata) {
+  const error = { error: { code, message, retryable, suggestion } };
+  if (correctedExample) error.error.corrected_example = correctedExample;
+  if (metadata) error.error.metadata = metadata;
   return error;
 }
 
-// Parse API error response and convert to structured format
 function parseAPIError(status, statusText, endpoint) {
   if (status === 404 && endpoint.includes('/networks/')) {
-    const networkMatch = endpoint.match(/\/networks\/([^\/\?]+)/);
+    const networkMatch = endpoint.match(/\/networks\/([^/?]+)/);
     const providedNetwork = networkMatch ? networkMatch[1] : 'unknown';
     return buildErrorResponse(
       ErrorCodes.DP400_INVALID_NETWORK,
       `Network ID '${providedNetwork}' not recognized`,
       true,
-      "Use normalized network ID from getNetworks. Call getCapabilities for network_synonyms.",
+      'Use normalized network ID from getNetworks. Call getCapabilities for network_synonyms.',
       `getNetworkPools('ethereum', 10)`,
       {
         provided: providedNetwork,
-        suggested: "ethereum",
-        valid_networks: ["ethereum", "bsc", "polygon", "base", "arbitrum", "optimism", "solana", "avalanche", "fantom"]
-      }
+        suggested: 'ethereum',
+        valid_networks: ['ethereum', 'bsc', 'polygon', 'base', 'arbitrum', 'optimism', 'solana', 'avalanche', 'fantom'],
+      },
     );
   }
 
   if (status === 404) {
     return buildErrorResponse(
       ErrorCodes.DP404_NOT_FOUND,
-      "Resource not found",
+      'Resource not found',
       false,
-      "Verify the resource exists. Use search or list endpoints to find correct identifiers.",
+      'Verify the resource exists. Use search or list endpoints to find correct identifiers.',
       undefined,
-      { endpoint }
+      { endpoint },
     );
   }
 
@@ -73,15 +153,14 @@ function parseAPIError(status, statusText, endpoint) {
     resetTime.setHours(24, 0, 0, 0);
     return buildErrorResponse(
       ErrorCodes.DP429_RATE_LIMIT,
-      "Daily rate limit of 10,000 requests exceeded",
+      'Daily rate limit exceeded',
       true,
-      "Wait until rate limit resets or use cached data",
+      'Wait until rate limit resets or use cached data',
       undefined,
       {
-        limit: 10000,
         reset_at: resetTime.toISOString(),
-        retry_after_seconds: Math.floor((resetTime.getTime() - Date.now()) / 1000)
-      }
+        retry_after_seconds: Math.floor((resetTime.getTime() - Date.now()) / 1000),
+      },
     );
   }
 
@@ -90,9 +169,9 @@ function parseAPIError(status, statusText, endpoint) {
       ErrorCodes.DP400_MISSING_REQUIRED,
       `Bad request: ${statusText}`,
       false,
-      "Check that all required parameters are provided with correct formats",
+      'Check that all required parameters are provided with correct formats',
       undefined,
-      { endpoint, status }
+      { endpoint, status },
     );
   }
 
@@ -100,1142 +179,888 @@ function parseAPIError(status, statusText, endpoint) {
     `DP${status}_ERROR`,
     `API request failed: ${status} ${statusText}`,
     false,
-    "Check API documentation or try again later",
+    'Check API documentation or try again later',
     undefined,
-    { endpoint, status }
+    { endpoint, status },
   );
 }
 
-// Rate limit tracking
-let requestCount = 0;
-const RATE_LIMIT = 10000;
-
-// Helper function to fetch data from DexPaprika API with structured error handling
+// ─────────────────────────────────────────────────────────────────────────────
+// Wire chokepoint. The network-synonym rewrite happens here, before the URL is
+// composed, so eth -> ethereum etc. resolve for every /networks/* endpoint.
+// Logging goes to stderr only (stdout carries the JSON-RPC frames).
+// ─────────────────────────────────────────────────────────────────────────────
 async function fetchFromAPI(endpoint) {
-  const startTime = Date.now();
-  const response = await fetch(`${API_BASE_URL}${endpoint}`);
-
+  // Synonym normalization so agent-supplied `eth`, `matic`, etc. route to the
+  // canonical network IDs. No-op for already-canonical IDs and non-/networks paths.
+  endpoint = normalizeNetworkPath(endpoint);
+  const url = `${API_BASE_URL}${endpoint}`;
+  const response = await fetch(url);
   if (!response.ok) {
-    const structuredError = parseAPIError(response.status, response.statusText, endpoint);
-    throw structuredError;
+    console.error(`[upstream] url=${url} http_status=${response.status} text="${response.statusText}"`);
+    // Preserve the package's structured error contract.
+    throw parseAPIError(response.status, response.statusText, endpoint);
   }
+  return response.json();
+}
 
-  const data = await response.json();
-  requestCount++;
-  const responseTime = Date.now() - startTime;
-
-  const resetTime = new Date();
-  resetTime.setHours(24, 0, 0, 0);
-
-  return {
-    data,
-    meta: {
-      rate_limit: {
-        limit: RATE_LIMIT,
-        remaining: RATE_LIMIT - requestCount,
-        used: requestCount,
-        percentage_used: (requestCount / RATE_LIMIT) * 100,
-        reset_at: resetTime.toISOString()
-      },
-      response_time_ms: responseTime,
-      cached: false,
-      timestamp: new Date().toISOString()
+// ─────────────────────────────────────────────────────────────────────────────
+// Response helpers (ported from src/tools/responses.ts).
+// jsonText returns BOTH content[0].text (JSON string) AND structuredContent.
+// ─────────────────────────────────────────────────────────────────────────────
+function jsonText(data, structuredKey) {
+  const result = {
+    content: [{ type: 'text', text: JSON.stringify(data, null, 2) }],
+  };
+  if (data !== null && typeof data === 'object') {
+    if (Array.isArray(data)) {
+      if (structuredKey) result.structuredContent = { [structuredKey]: data };
+      // else: keep content-only (older callers that haven't migrated)
+    } else {
+      result.structuredContent = data;
     }
+  }
+  return result;
+}
+
+function errorText(err) {
+  // Structured error objects (from parseAPIError) surface their full payload so
+  // agents keep the actionable code/suggestion. Plain errors fall back to message.
+  if (err && typeof err === 'object' && 'error' in err) {
+    return {
+      content: [{ type: 'text', text: JSON.stringify(err, null, 2) }],
+    };
+  }
+  return {
+    content: [{
+      type: 'text',
+      text: `Error: ${err instanceof Error ? err.message : 'Unknown error'}`,
+    }],
   };
 }
 
-// Helper to format response for MCP
-function formatMcpResponse(data) {
-  return {
-    content: [
-      {
-        type: "text",
-        text: JSON.stringify(data, null, 2)
-      }
-    ]
-  };
+// MCP tool annotations.
+const ANNOTATIONS_READ_ONLY = {
+  readOnlyHint: true,
+  idempotentHint: true,
+  destructiveHint: false,
+  openWorldHint: true,
+};
+const ANNOTATIONS_WRITE_FEEDBACK = {
+  readOnlyHint: false,
+  idempotentHint: false,
+  destructiveHint: false,
+  openWorldHint: false,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// rationale field — REQUIRED on every read tool (all tools except submitFeedback).
+// Accepted by the handler and IGNORED (no analytics sink; no D1 in stdio).
+// ─────────────────────────────────────────────────────────────────────────────
+const RATIONALE_DESCRIPTION =
+  'REQUIRED. 1-2 sentence rationale for this call (e.g. "User asked for X; calling Y to fetch Z"). ' +
+  'Logged for MCP improvement, never shown to end users. No PII or secrets. ' +
+  'See the server `instructions` field for the full convention and worked examples.';
+
+const rationaleZod = z.string().min(20).max(500).describe(RATIONALE_DESCRIPTION);
+
+// Coerce page=0 (and any non-positive) to 1 in paginated handlers.
+function coercePage(page) {
+  return page && page > 0 ? page : 1;
 }
 
-// Helper to format MCP error response
-function formatMcpError(error) {
-  if (error && typeof error === 'object' && 'error' in error) {
-    return formatMcpResponse(error);
-  }
-  return formatMcpResponse({
-    error: {
-      code: "DP500_UNEXPECTED",
-      message: error instanceof Error ? error.message : 'Unknown error',
-      retryable: false,
-      suggestion: "Please try again later or contact support"
-    }
-  });
+// ─────────────────────────────────────────────────────────────────────────────
+// SERVER_INSTRUCTIONS (ported from src/tools/responses.ts) — advertised once per
+// session via the MCP initialize result.instructions. Truthful for stdio.
+// ─────────────────────────────────────────────────────────────────────────────
+const SERVER_INSTRUCTIONS = [
+  '# DexPaprika MCP — agent usage notes',
+  '',
+  '## `rationale` field (required on every read tool)',
+  'Every read tool (`getNetworks`, `getPoolDetails`, etc.) requires a `rationale` string of 20-500 chars.',
+  'Format: 1-2 sentences referencing (a) what triggered the call and (b) downstream use.',
+  'Do not include user PII or secrets. Rationales are accepted to satisfy the schema and never persisted in the self-host build.',
+  '',
+  'Examples:',
+  '- "User asked for SOL price; calling getTokenDetails to fetch current USD value."',
+  '- "Building a portfolio dashboard; need top pools for WETH on ethereum to estimate liquidity."',
+  '- "Backtesting USDC/WETH spread; fetching 24h OHLCV at 1h interval."',
+  '',
+  '`submitFeedback` is the exception — it has its own `goal`/`expected`/`observed` fields which serve as the rationale.',
+  '',
+  '## Tool discovery',
+  'Start with `getNetworks` (discover supported chains) or `getCapabilities` (agent-onboarding doc: network synonyms, workflow patterns, common pitfalls). Both are free and have no parameters beyond rationale.',
+  '',
+  '## Parameter naming',
+  'Sort parameters accept both legacy and canonical names — pick whichever is clearer; the server normalizes both. Canonical names (preferred going forward):',
+  '- `sort_dir` (legacy: `sort`) — sort direction, "asc" or "desc".',
+  '- `sort_by` (legacy: `order_by`) — sort field, tool-specific enum.',
+  '',
+  '`getTokenPools` also accepts:',
+  "- `inversed` (legacy: `reorder`) — flip pool's pair perspective.",
+  '- `paired_token_address` (legacy: `address`) — filter pools that also contain this token.',
+  '',
+  'Pagination is 1-indexed; the server accepts `page=0` as a backward-compat alias for `page=1`.',
+  '',
+  '## Time formats',
+  '- `getPoolOHLCV.start` / `.end`: RFC3339 recommended (`2024-01-01T00:00:00Z`). Also accepts Unix epoch seconds and `YYYY-MM-DD` (treated as 00:00:00 UTC).',
+  '- `getPoolTransactions.from` / `.to`: Unix epoch SECONDS only. Window capped to last 7 days.',
+  '',
+  '## Output shape',
+  "All tools return both `content[0].text` (JSON string, for older clients) and `structuredContent` (validated against the tool's `outputSchema`, 2025-06-18+). Prefer `structuredContent` to avoid the parse round-trip.",
+  '',
+  'Array-returning tools wrap the array under a named key in structuredContent — `getNetworks` → `{ networks: [...] }`, `getPoolOHLCV` → `{ ohlcv: [...] }`, `getTokenMultiPrices` → `{ prices: [...] }`.',
+].join('\n');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reusable output subschemas (ported from src/tools/output-schemas.ts).
+// Every nested object uses .passthrough() so upstream can add fields safely.
+// ─────────────────────────────────────────────────────────────────────────────
+const PageInfo = z.object({
+  limit: z.number().optional().describe('Items per page in the request.'),
+  page: z.number().optional().describe('Current page number (1-indexed).'),
+  total_items: z.number().optional().describe('Total number of items across all pages.'),
+  total_pages: z.number().optional().describe('Total number of pages available.'),
+}).passthrough();
+
+const TokenSummary = z.object({
+  id: z.string().optional().describe('Token contract address (chain-canonical form).'),
+  name: z.string().optional(),
+  symbol: z.string().optional(),
+  chain: z.string().optional(),
+  decimals: z.number().optional(),
+  fdv: z.number().nullable().optional().describe('Fully-diluted valuation in USD.'),
+  added_at: z.string().optional().describe('ISO 8601 timestamp when DexPaprika first indexed this token.'),
+}).passthrough();
+
+const PoolSummary = z.object({
+  id: z.string().optional().describe('Pool contract address.'),
+  chain: z.string().optional().describe("Network slug (e.g. 'ethereum'). Note: also exposed as 'network' on some endpoints."),
+  dex_id: z.string().optional(),
+  dex_name: z.string().optional(),
+  fee: z.number().nullable().optional().describe('Pool fee (units depend on DEX; null for some DEXes).'),
+  created_at: z.string().optional().describe('ISO 8601 pool-creation timestamp.'),
+  created_at_block_number: z.number().optional(),
+  tokens: z.array(TokenSummary).optional(),
+  last_price: z.number().nullable().optional(),
+  last_price_usd: z.number().nullable().optional(),
+}).passthrough();
+
+const DexSummary = z.object({
+  id: z.string().optional(),
+  dex_id: z.string().optional(),
+  display_name: z.string().optional(),
+  dex_name: z.string().optional(),
+  chain: z.string().optional(),
+  network_id: z.string().optional(),
+  protocol: z.string().optional(),
+  volume_usd_24h: z.number().optional(),
+  txns_24h: z.number().optional(),
+  pools_count: z.number().optional(),
+}).passthrough();
+
+const NetworkSummary = z.object({
+  display_name: z.string().optional().describe("Human-readable network name (e.g. 'Ethereum')."),
+  id: z.string().optional().describe("Network slug for use in other endpoints (e.g. 'ethereum')."),
+  volume_usd_24h: z.number().optional().describe('Total 24h trading volume across all pools on this network, USD.'),
+  txns_24h: z.number().optional().describe('Total transactions in the last 24h on this network.'),
+  pools_count: z.number().optional().describe('Number of indexed pools on this network.'),
+}).passthrough();
+
+const OHLCVRow = z.object({
+  time_open: z.string().optional().describe('ISO 8601 timestamp of bucket open.'),
+  time_close: z.string().optional().describe('ISO 8601 timestamp of bucket close (inclusive at 23:59:59 for 24h).'),
+  open: z.number().optional(),
+  high: z.number().optional(),
+  low: z.number().optional(),
+  close: z.number().optional(),
+  volume: z.number().optional().describe('Trade volume in the bucket, in pair-quote units (or USD where applicable).'),
+}).passthrough();
+
+const PoolTransaction = z.object({
+  id: z.string().optional(),
+  block_number: z.number().optional(),
+  block_timestamp: z.string().optional(),
+  pool_id: z.string().optional(),
+  token0: z.unknown().optional(),
+  token1: z.unknown().optional(),
+  amount_usd: z.number().optional(),
+}).passthrough();
+
+const PriceEntry = z.object({
+  chain: z.string().optional(),
+  id: z.string().optional().describe('Token contract address.'),
+  price_usd: z.number().nullable().optional().describe('Current USD price; null if not available.'),
+}).passthrough();
+
+// Per-tool output schema RAW SHAPES (Record<string, ZodTypeAny>). Wrapped in
+// z.object(shape).passthrough() at registration so the outer level also allows
+// extra fields (additionalProperties:true), matching the worker.
+const OUTPUT_SCHEMAS = {
+  getNetworks: {
+    networks: z.array(NetworkSummary).describe('All supported blockchain networks with current 24h volume + indexing stats.'),
+  },
+  getStats: {
+    chains: z.number().describe('Total chains indexed.'),
+    factories: z.number().describe('Total DEX factory contracts indexed.'),
+    pools: z.number().describe('Total pools indexed across all chains.'),
+    tokens: z.number().describe('Total tokens indexed.'),
+  },
+  getCapabilities: {
+    server: z.object({ name: z.string(), version: z.string() }).passthrough(),
+    stats: z.object({
+      networks: z.number(),
+      tokens_approx: z.number(),
+      pools_approx: z.number(),
+      free: z.boolean(),
+      requires_api_key: z.boolean(),
+    }).passthrough(),
+    network_synonyms: z.record(z.string(), z.array(z.string())).describe('Canonical network id -> common alternates an agent might try.'),
+    workflows: z.record(z.string(), z.array(z.string())).describe('Named tool sequences for common agent tasks.'),
+    common_pitfalls: z.array(z.string()).describe('Known edge cases agents should be aware of.'),
+    documentation: z.string(),
+    agent_skills: z.string(),
+  },
+
+  // NOTE: the array/page_info keys below are marked .optional() so SDK 1.29's
+  // strict structuredContent validation accepts real upstream shapes. The outer
+  // schema is .passthrough(), so the documented key (e.g. `results`) is advertised
+  // while alternate upstream keys still validate. filterNetworkTokens is the key
+  // case: the live API returns `{ data, page_info, query }`, not `{ results }`,
+  // so a required `results` would reject every response. Same defensive reasoning
+  // for the rest — upstream key presence varies and must not hard-fail the client.
+  search: {
+    tokens: z.array(TokenSummary).optional(),
+    pools: z.array(PoolSummary).optional(),
+    dexes: z.array(DexSummary).optional(),
+  },
+
+  getNetworkDexes: { dexes: z.array(DexSummary).optional(), page_info: PageInfo.optional() },
+  getNetworkPools: { pools: z.array(PoolSummary).optional(), page_info: PageInfo.optional() },
+  getDexPools: { pools: z.array(PoolSummary).optional(), page_info: PageInfo.optional() },
+  getNetworkPoolsFilter: { results: z.array(PoolSummary).optional(), page_info: PageInfo.optional() },
+  getTokenPools: { pools: z.array(PoolSummary).optional(), page_info: PageInfo.optional() },
+  getTopTokens: { tokens: z.array(TokenSummary).optional(), page_info: PageInfo.optional() },
+  filterNetworkTokens: { results: z.array(TokenSummary).optional(), page_info: PageInfo.optional() },
+
+  getPoolDetails: {
+    id: z.string().optional(),
+    chain: z.string().optional(),
+    factory_id: z.string().optional(),
+    dex_id: z.string().optional(),
+    dex_name: z.string().optional(),
+    created_at: z.string().optional(),
+    created_at_block_number: z.number().optional(),
+    fee: z.number().nullable().optional(),
+    tokens: z.array(TokenSummary).optional(),
+    token_reserves: z.array(z.unknown()).optional(),
+    last_price: z.number().nullable().optional(),
+    last_price_usd: z.number().nullable().optional(),
+    price_time: z.string().optional(),
+    price_stats: z.unknown().optional(),
+  },
+  getTokenDetails: {
+    id: z.string().optional(),
+    name: z.string().optional(),
+    symbol: z.string().optional(),
+    chain: z.string().optional(),
+    decimals: z.number().optional(),
+    total_supply: z.union([z.number(), z.string()]).optional().describe('Raw on-chain total supply. Big numbers may overflow JS Number — handle as string for tokens with 18+ decimals.'),
+    description: z.string().optional(),
+    website: z.string().optional(),
+    has_image: z.boolean().optional(),
+    added_at: z.string().optional(),
+    price_stats: z.unknown().optional(),
+    summary: z.unknown().optional(),
+  },
+
+  getPoolOHLCV: {
+    ohlcv: z.array(OHLCVRow).describe('Open-High-Low-Close-Volume rows ordered by time_open ascending.'),
+  },
+  getPoolTransactions: {
+    transactions: z.array(PoolTransaction),
+    page_info: PageInfo,
+  },
+  getTokenMultiPrices: {
+    prices: z.array(PriceEntry).describe('USD prices for the requested tokens, in input order.'),
+    missing_tokens: z.array(z.string()).optional().describe('Input tokens that upstream could not price (invalid address, no liquidity, unknown contract). Empty array when all input tokens were resolved.'),
+  },
+
+  submitFeedback: {
+    ok: z.boolean().describe('True if the feedback was accepted.'),
+    tracking_id: z.string().nullable().optional().describe('Stable id agents can reference in follow-up submissions; null if persistence failed.'),
+    message: z.string(),
+    severity: z.enum(['blocker', 'major', 'minor', 'nit']).optional(),
+  },
+};
+
+// Build the permissive (outer-passthrough) outputSchema for a tool name.
+function outputSchemaFor(name) {
+  const shape = OUTPUT_SCHEMAS[name];
+  if (!shape) return undefined;
+  return z.object(shape).passthrough();
 }
 
-// Build capabilities document
-async function buildCapabilitiesDocument() {
-  let supportedNetworks = [];
-  try {
-    const res = await fetch(`${API_BASE_URL}/networks`);
-    if (res.ok) {
-      const json = await res.json();
-      supportedNetworks = Array.isArray(json) ? json.map(n => n.id).filter(Boolean) : [];
-    }
-  } catch { /* ignore */ }
-
-  const synonymsMaster = {
-    ethereum: ["eth", "ethereum", "mainnet", "erc20"],
-    bsc: ["binance smart chain", "bnb chain", "binance", "bnb", "bsc", "bep20"],
-    polygon: ["matic", "polygon", "poly"],
-    arbitrum: ["arb", "arbitrum", "arbitrum one"],
-    optimism: ["op", "optimism"],
-    base: ["base", "base chain"],
-    avalanche: ["avax", "avalanche", "c-chain"],
-    solana: ["sol", "solana"],
-    fantom: ["ftm", "fantom"],
-    blast: ["blast"],
-    zksync: ["zk", "zksync", "zksync era"],
-    linea: ["linea"],
-    scroll: ["scroll"],
-    mantle: ["mantle", "mnt"],
-    celo: ["celo"],
-    cronos: ["cro", "cronos"],
-    aptos: ["apt", "aptos"],
-    sui: ["sui"],
-    ton: ["ton", "the open network"],
-    tron: ["trx", "tron"],
-  };
-
-  const network_synonyms = {};
-  const keys = supportedNetworks.length > 0 ? supportedNetworks : Object.keys(synonymsMaster);
-  for (const k of keys) {
-    if (synonymsMaster[k]) network_synonyms[k] = synonymsMaster[k];
-  }
-
-  const now = new Date();
-  const lastUpdated = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
-
+// ─────────────────────────────────────────────────────────────────────────────
+// getCapabilities document (ported verbatim from src/tools/meta.ts). Local-only,
+// no upstream call. network_synonyms references the same NETWORK_SYNONYMS map to
+// remove the worker's hand-sync footgun (behavior-identical object).
+// ─────────────────────────────────────────────────────────────────────────────
+function buildCapabilitiesDocument() {
   return {
-    service: "dexpaprika",
-    // Known misspellings, surfaced so MCP catalogs / tool routers / agent
-    // frameworks can match fuzzy references back to us (devrel#6).
-    aliases: ["dexpapika", "dexpaprica", "dex-paprika", "dex paprika"],
-    version: SERVER_VERSION,
-    description: "DeFi analytics across 33 blockchain networks",
-    server: {
-      name: "DexPaprika MCP Server",
-      version: SERVER_VERSION,
-      description: "DeFi data aggregation across multiple blockchain networks and DEXes",
-      last_updated: lastUpdated,
-      documentation_url: "https://docs.dexpaprika.com",
+    name: SERVER_CANONICAL_NAME,
+    aliases: SERVER_ALIASES,
+    server: { name: 'DexPaprika MCP', version: '2.0.0' },
+    tools_count: 17,
+    stats: {
+      networks: 35,
+      tokens_approx: 29_000_000,
+      pools_approx: 31_000_000,
+      free: true,
+      requires_api_key: false,
     },
-    tools: [
-      {
-        name: "getNetworks",
-        description: "List all supported blockchain networks",
-        category: "discovery",
-        parameters: {},
-        returns: { type: "array", items: "Network" },
-        cost: 1
-      },
-      {
-        name: "getCapabilities",
-        description: "Return server capabilities, workflow patterns, network synonyms, common pitfalls, and best-practice sequences",
-        category: "discovery",
-        parameters: {},
-        returns: { type: "object" },
-        cost: 1
-      },
-      {
-        name: "getNetworkDexes",
-        description: "Get available DEXes on a specific network",
-        category: "dexes",
-        parameters: {
-          network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
-          page: { type: "number", required: false, default: 1, description: "Page number (1-indexed)" },
-          limit: { type: "number", required: false, default: 10, max: 100, description: "Items per page" },
-          sort: { type: "string", required: false, enum: ["asc", "desc"], default: "desc" },
-          order_by: { type: "string", required: false, enum: ["pool"] }
-        },
-        returns: { type: "object", properties: ["dexes", "page_info"] },
-        cost: 1
-      },
-      {
-        name: "getNetworkPools",
-        description: "Get top liquidity pools on a network",
-        category: "pools",
-        parameters: {
-          network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
-          page: { type: "number", required: false, default: 1 },
-          limit: { type: "number", required: false, default: 10, max: 100 },
-          sort: { type: "string", required: false, enum: ["asc", "desc"], default: "desc" },
-          order_by: { type: "string", required: false, enum: ["volume_usd", "price_usd", "transactions", "last_price_change_usd_24h", "created_at"], default: "volume_usd" }
-        },
-        returns: { type: "object", properties: ["pools", "page_info"] },
-        cost: 1
-      },
-      {
-        name: "getDexPools",
-        description: "Get pools from a specific DEX on a network",
-        category: "pools",
-        parameters: {
-          network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
-          dex: { type: "string", required: true, description: "DEX identifier", example: "uniswap_v3" },
-          page: { type: "number", required: false, default: 1 },
-          limit: { type: "number", required: false, default: 10, max: 100 },
-          sort: { type: "string", required: false, enum: ["asc", "desc"], default: "desc" },
-          order_by: { type: "string", required: false, enum: ["volume_usd", "price_usd", "transactions", "last_price_change_usd_24h", "created_at"], default: "volume_usd" }
-        },
-        returns: { type: "object", properties: ["pools", "page_info"] },
-        cost: 1
-      },
-      {
-        name: "getNetworkPoolsFilter",
-        description: "Filter pools by volume, liquidity, transactions, and creation time",
-        category: "pools",
-        parameters: {
-          network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
-          page: { type: "number", required: false, default: 1 },
-          limit: { type: "number", required: false, default: 50, max: 100 },
-          volume_24h_min: { type: "number", required: false, description: "Minimum 24h volume USD" },
-          volume_24h_max: { type: "number", required: false, description: "Maximum 24h volume USD" },
-          volume_7d_min: { type: "number", required: false, description: "Minimum 7d volume USD" },
-          volume_7d_max: { type: "number", required: false, description: "Maximum 7d volume USD" },
-          liquidity_usd_min: { type: "number", required: false, description: "Minimum pool liquidity USD" },
-          liquidity_usd_max: { type: "number", required: false, description: "Maximum pool liquidity USD" },
-          txns_24h_min: { type: "number", required: false, description: "Minimum 24h transactions" },
-          created_after: { type: "number", required: false, description: "UNIX timestamp" },
-          created_before: { type: "number", required: false, description: "UNIX timestamp" },
-          sort_by: { type: "string", required: false, enum: ["volume_24h", "volume_7d", "volume_30d", "liquidity", "txns_24h", "created_at"], default: "volume_24h" },
-          sort_dir: { type: "string", required: false, enum: ["asc", "desc"], default: "desc" }
-        },
-        returns: { type: "object", properties: ["results", "page_info"] },
-        cost: 1,
-        note: "Response uses 'results' key (not 'pools'). Fields: address, volume_usd_24h, volume_usd_7d, liquidity_usd, txns_24h."
-      },
-      {
-        name: "filterNetworkTokens",
-        description: "Filter tokens by volume, liquidity, FDV, transactions, and creation time",
-        category: "tokens",
-        parameters: {
-          network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
-          page: { type: "number", required: false, default: 1 },
-          limit: { type: "number", required: false, default: 50, max: 100 },
-          volume_24h_min: { type: "number", required: false, description: "Minimum 24h volume USD" },
-          volume_24h_max: { type: "number", required: false, description: "Maximum 24h volume USD" },
-          liquidity_usd_min: { type: "number", required: false, description: "Minimum token liquidity USD" },
-          fdv_min: { type: "number", required: false, description: "Minimum fully diluted valuation USD" },
-          fdv_max: { type: "number", required: false, description: "Maximum fully diluted valuation USD" },
-          txns_24h_min: { type: "number", required: false, description: "Minimum 24h transactions" },
-          created_after: { type: "number", required: false, description: "UNIX timestamp" },
-          created_before: { type: "number", required: false, description: "UNIX timestamp" },
-          sort_by: { type: "string", required: false, enum: ["volume_24h", "volume_7d", "volume_30d", "liquidity_usd", "txns_24h", "created_at", "fdv"], default: "volume_24h" },
-          sort_dir: { type: "string", required: false, enum: ["asc", "desc"], default: "desc" }
-        },
-        returns: { type: "object", properties: ["results", "page_info"] },
-        cost: 1,
-        note: "Response uses 'results' key. Fields: chain, address, price_usd, volume_usd_24h, volume_usd_7d, liquidity_usd, fdv_usd, txns_24h, created_at."
-      },
-      {
-        name: "getTopTokens",
-        description: "Get top tokens on a network ranked by volume, price, liquidity, or activity",
-        category: "tokens",
-        parameters: {
-          network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
-          page: { type: "number", required: false, default: 1 },
-          limit: { type: "number", required: false, default: 50, max: 100 },
-          order_by: { type: "string", required: false, enum: ["volume_24h", "price_usd", "liquidity_usd", "txns", "price_change"], default: "volume_24h" },
-          sort: { type: "string", required: false, enum: ["asc", "desc"], default: "desc" }
-        },
-        returns: { type: "object", properties: ["tokens", "page_info"] },
-        cost: 1,
-        note: "Each token includes enriched metadata + multi-timeframe metrics (24h, 1h, 5m) with volume, buys, sells, txns, price change."
-      },
-      {
-        name: "getPoolDetails",
-        description: "Get detailed info about a pool",
-        category: "pools",
-        parameters: {
-          network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
-          pool_address: { type: "string", required: true, description: "Pool address", example: "0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640" },
-          inversed: { type: "boolean", required: false, default: false, description: "Invert price ratio" }
-        },
-        returns: { type: "object" },
-        cost: 1
-      },
-      {
-        name: "getPoolOHLCV",
-        description: "Get historical price data (OHLCV) for a pool",
-        category: "pools",
-        parameters: {
-          network: { type: "string", required: true },
-          pool_address: { type: "string", required: true },
-          start: { type: "string", required: true, description: "Start time (Unix timestamp, RFC3339, or yyyy-mm-dd)" },
-          end: { type: "string", required: false },
-          limit: { type: "number", required: false, default: 1, max: 366 },
-          interval: { type: "string", required: false, enum: ["1m", "5m", "10m", "15m", "30m", "1h", "6h", "12h", "24h"], default: "24h" },
-          inversed: { type: "boolean", required: false, default: false }
-        },
-        returns: { type: "array", items: "OHLCVRecord" },
-        cost: 1
-      },
-      {
-        name: "getPoolTransactions",
-        description: "Get recent transactions for a pool",
-        category: "pools",
-        parameters: {
-          network: { type: "string", required: true },
-          pool_address: { type: "string", required: true },
-          page: { type: "number", required: false, default: 1, max: 100 },
-          limit: { type: "number", required: false, default: 10, max: 100 },
-          cursor: { type: "string", required: false, description: "Transaction ID for cursor pagination" },
-          from: { type: "number", required: false, description: "Filter transactions starting from this UNIX timestamp" },
-          to: { type: "number", required: false, description: "Filter transactions up to this UNIX timestamp" }
-        },
-        returns: { type: "object", properties: ["transactions", "page_info"] },
-        cost: 1
-      },
-      {
-        name: "getTokenDetails",
-        description: "Get detailed information about a token",
-        category: "tokens",
-        parameters: {
-          network: { type: "string", required: true },
-          token_address: { type: "string", required: true, description: "Token contract address", example: "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN" }
-        },
-        returns: { type: "object" },
-        cost: 1
-      },
-      {
-        name: "getTokenPools",
-        description: "Get liquidity pools containing a token",
-        category: "tokens",
-        parameters: {
-          network: { type: "string", required: true },
-          token_address: { type: "string", required: true },
-          page: { type: "number", required: false, default: 1 },
-          limit: { type: "number", required: false, default: 10, max: 100 },
-          sort: { type: "string", required: false, enum: ["asc", "desc"], default: "desc" },
-          order_by: { type: "string", required: false, enum: ["volume_usd", "price_usd", "transactions", "last_price_change_usd_24h", "created_at"], default: "volume_usd" },
-          reorder: { type: "boolean", required: false },
-          address: { type: "string", required: false, description: "Filter by additional token address" }
-        },
-        returns: { type: "object", properties: ["pools", "page_info"] },
-        cost: 1
-      },
-      {
-        name: "getTokenMultiPrices",
-        description: "Batch fetch prices for up to 10 tokens",
-        category: "tokens",
-        parameters: {
-          network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
-          tokens: { type: "array", required: true, format: "comma-separated", max_items: 10, description: "Up to 10 token addresses", example: ["0x123...", "0x456..."] }
-        },
-        returns: { type: "array", items: "TokenPrice" },
-        cost: 1
-      },
-      {
-        name: "search",
-        description: "Search across ALL networks for tokens, pools, and DEXes by name, symbol, or address",
-        category: "search",
-        parameters: {
-          query: { type: "string", required: true, description: "Search term", example: "uniswap" }
-        },
-        returns: { type: "object", properties: ["tokens", "pools", "dexes"] },
-        cost: 1
-      },
-      {
-        name: "getStats",
-        description: "Get high-level statistics about the DexPaprika ecosystem",
-        category: "utils",
-        parameters: {},
-        returns: { type: "object", properties: ["chains", "factories", "pools", "tokens"] },
-        cost: 1
-      }
+    network_synonyms: NETWORK_SYNONYMS,
+    workflows: {
+      discover_networks: ['getNetworks'],
+      find_pools_on_network: ['getNetworks', 'getNetworkPools'],
+      filter_pools_by_volume: ['getNetworks', 'getNetworkPoolsFilter'],
+      find_new_pools: [
+        'getNetworkPoolsFilter with created_after',
+        'sort_by=created_at sort_dir=desc',
+      ],
+      token_details_and_pools: ['getTokenDetails', 'getTokenPools'],
+      batch_price_lookup: ['getTokenMultiPrices (max 10 tokens per call)'],
+      top_tokens_on_network: ['getTopTokens'],
+      filter_tokens_by_metrics: ['filterNetworkTokens'],
+      historical_price_chart: ['getPoolOHLCV with start + interval'],
+      recent_swaps: ['getPoolTransactions with from/to UNIX timestamps'],
+      cross_network_search: ['search with token name/symbol/address'],
+    },
+    common_pitfalls: [
+      '/pools (global) returns 410 Gone — use /networks/{network}/pools instead',
+      'getTokenMultiPrices is capped at 10 tokens per request',
+      'getPoolTransactions from/to are UNIX timestamps; results always capped to last 7 days',
+      "Token addresses must match the network (e.g., don't send a Solana address to ethereum queries)",
     ],
-    network_synonyms,
-    validation_rules: {
-      address_formats: {
-        ethereum: "^0x[a-fA-F0-9]{40}$",
-        bsc: "^0x[a-fA-F0-9]{40}$",
-        polygon: "^0x[a-fA-F0-9]{40}$",
-        arbitrum: "^0x[a-fA-F0-9]{40}$",
-        optimism: "^0x[a-fA-F0-9]{40}$",
-        base: "^0x[a-fA-F0-9]{40}$",
-        avalanche: "^0x[a-fA-F0-9]{40}$",
-        fantom: "^0x[a-fA-F0-9]{40}$",
-        blast: "^0x[a-fA-F0-9]{40}$",
-        zksync: "^0x[a-fA-F0-9]{40}$",
-        linea: "^0x[a-fA-F0-9]{40}$",
-        scroll: "^0x[a-fA-F0-9]{40}$",
-        mantle: "^0x[a-fA-F0-9]{40}$",
-        celo: "^0x[a-fA-F0-9]{40}$",
-        cronos: "^0x[a-fA-F0-9]{40}$",
-        solana: "^[1-9A-HJ-NP-Za-km-z]{32,44}$",
-        aptos: "^0x[a-fA-F0-9]{64}$",
-        sui: "^0x[a-fA-F0-9]{64}$",
-        ton: "^[A-Za-z0-9_-]{48}$",
-        tron: "^T[A-Za-z1-9]{33}$"
-      },
-      batch_limits: {
-        getTokenMultiPrices: 10
-      }
-    },
-    rate_limits: {
-      requests_per_day: 10000,
-      burst_limit: 100
-    },
-    error_codes: {
-      DP400_INVALID_NETWORK: "Network ID not recognized. Use network_synonyms to normalize input.",
-      DP400_TOO_MANY_TOKENS: "Exceeded batch limit. Max {limit} tokens per request.",
-      DP400_INVALID_ADDRESS: "Token address format invalid for this network.",
-      DP400_MISSING_REQUIRED: "Required parameter missing.",
-      DP404_NOT_FOUND: "Resource not found. May not exist or be delisted.",
-      DP429_RATE_LIMIT: "Daily rate limit exceeded. Resets at {reset_at}."
-    },
-    meta: {
-      documentation: "https://docs.dexpaprika.com",
-      support: "https://github.com/coinpaprika/claude-marketplace"
-    },
-    workflow_patterns: {
-      discovery: {
-        description: "Discover available networks, DEXes, and pools",
-        steps: [
-          "getNetworks - List all supported blockchain networks",
-          "getNetworkDexes - Find DEXes on a specific network",
-          "getNetworkPools - Browse top liquidity pools",
-        ],
-        example_use_case: "Finding the most active trading pools on a network",
-      },
-      price_tracking: {
-        description: "Track token prices and historical data",
-        steps: [
-          "search - Find token by name, symbol, or address",
-          "getTokenDetails - Get current price and metadata",
-          "getTokenPools - Find all pools containing the token",
-          "getPoolOHLCV - Get historical price data (candlestick charts)",
-        ],
-        example_use_case: "Analyzing price trends for a specific token over 7 days",
-      },
-      multi_price: {
-        description: "Get prices for multiple tokens at once (batch operation)",
-        steps: [
-          "getNetworks - Verify network ID",
-          "getTokenMultiPrices - Fetch up to 10 token prices in one call",
-        ],
-        example_use_case: "Building a portfolio tracker showing multiple token prices",
-        limitations: "Maximum 10 tokens per request",
-      },
-      find_tokens_by_mcap: {
-        description: "Discover tokens within specific market cap ranges",
-        steps: [
-          "getNetworkPools - Get pools sorted by volume",
-          "Extract tokens[].fdv (Fully Diluted Valuation) from response",
-          "Filter tokens where fdv is in your target range (e.g., $10M-$100M)",
-          "getTokenDetails - Deep dive into promising candidates",
-        ],
-        example_use_case: "Finding mid-cap tokens ($10M-$100M) with high trading volume",
-        note: "Currently requires client-side filtering by fdv field",
-      },
-      technical_analysis: {
-        description: "Perform comprehensive technical analysis on a token",
-        steps: [
-          "search - Locate token by name/symbol",
-          "getTokenDetails - Get current metrics (price, fdv, volume)",
-          "getTokenPools - Identify highest liquidity pool",
-          "getPoolOHLCV - Fetch price history (OHLC candlesticks)",
-          "getPoolTransactions - Analyze recent trading activity",
-        ],
-        example_use_case: "Creating buy/sell signals based on price patterns and volume",
-        recommended_intervals: ["5m", "1h", "24h"],
-      },
-      whale_watching: {
-        description: "Monitor large transactions and whale activity",
-        steps: [
-          "getTokenPools - Find pools for target token",
-          "getPoolTransactions - Get recent transactions with details",
-          "Filter by amount_0 or amount_1 for large trades",
-          "Track sender/recipient addresses for patterns",
-        ],
-        example_use_case: "Alert when transactions >$100K occur",
-        tip: "Use cursor pagination for continuous monitoring",
-      },
-      new_token_discovery: {
-        description: "Find newly created tokens and pools",
-        steps: [
-          "getNetworkPools - Sort by created_at descending",
-          "getPoolDetails - Verify liquidity and token info",
-          "getPoolTransactions - Check initial trading activity",
-          "getTokenDetails - Validate token metrics",
-        ],
-        example_use_case: "Finding tokens launched in the last 24 hours",
-        warning: "New tokens are extremely high risk - verify contracts carefully",
-      },
-      dex_comparison: {
-        description: "Compare liquidity across different DEXes",
-        steps: [
-          "getNetworkDexes - List all DEXes on network",
-          "getDexPools - Get pools for each DEX",
-          "Compare volume_usd and transactions across DEXes",
-        ],
-        example_use_case: "Finding best liquidity for a trading pair",
-      },
-      pool_filtering: {
-        description: "Find pools matching specific criteria using server-side filters",
-        steps: [
-          "getNetworkPoolsFilter - Filter by volume, transactions, or creation time",
-          "getPoolDetails - Deep dive into matching pools",
-          "getPoolOHLCV - Analyze price history of filtered pools",
-        ],
-        example_use_case: "Finding high-volume pools created in the last 24 hours",
-        note: "More efficient than fetching all pools and filtering client-side",
-      },
-      arbitrage_opportunities: {
-        description: "Identify price discrepancies across pools",
-        steps: [
-          "getTokenPools - Get all pools for a token",
-          "Compare price_usd across different pools",
-          "getPoolDetails - Verify liquidity depth",
-          "Calculate potential arbitrage profit minus gas",
-        ],
-        example_use_case: "Finding price differences between DEXes",
-        note: "Consider gas fees, slippage, and MEV when calculating profitability",
-      },
-    },
-    parameter_examples: {
-      getNetworkPools: {
-        high_volume_pools: {
-          description: "Top 20 pools by 24h trading volume",
-          params: { network: "ethereum", limit: 20, order_by: "volume_usd", sort: "desc" },
-        },
-        new_pools: {
-          description: "Recently created pools (last 24h)",
-          params: { network: "bsc", order_by: "created_at", sort: "desc", limit: 50 },
-        },
-        most_transactions: {
-          description: "Pools with highest transaction count",
-          params: { network: "base", order_by: "transactions", sort: "desc", limit: 10 },
-        },
-        price_movers: {
-          description: "Pools with biggest 24h price changes",
-          params: { network: "solana", order_by: "last_price_change_usd_24h", sort: "desc", limit: 30 },
-        },
-      },
-      getPoolOHLCV: {
-        last_24h_hourly: {
-          description: "Hourly candlesticks for last 24 hours",
-          params: { network: "ethereum", pool_address: "0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640", start: "2025-10-15", interval: "1h", limit: 24 },
-        },
-        last_week_daily: {
-          description: "Daily candlesticks for last 7 days",
-          params: { network: "bsc", pool_address: "0x...", start: "2025-10-09", interval: "24h", limit: 7 },
-        },
-        intraday_5min: {
-          description: "5-minute intervals for day trading",
-          params: { network: "base", pool_address: "0x...", start: "2025-10-16T00:00:00Z", interval: "5m", limit: 288, inversed: false },
-        },
-        monthly_overview: {
-          description: "30 days of daily data",
-          params: { network: "arbitrum", pool_address: "0x...", start: "2025-09-16", interval: "24h", limit: 30 },
-        },
-      },
-      getPoolTransactions: {
-        recent_activity: {
-          description: "Last 50 transactions",
-          params: { network: "ethereum", pool_address: "0x...", limit: 50, page: 1 },
-        },
-        whale_trades: {
-          description: "Large transactions (filter client-side by volume)",
-          params: { network: "bsc", pool_address: "0x...", limit: 100, page: 1 },
-          post_filter: "Filter where volume_1 > 10000 for trades >$10K",
-        },
-        cursor_pagination: {
-          description: "Using cursor for efficient pagination",
-          params: { network: "polygon", pool_address: "0x...", limit: 20, cursor: "0xabcd1234..." },
-          note: "Use last transaction ID as cursor for next page",
-        },
-        time_range: {
-          description: "Transactions within a specific time window (last 7 days max)",
-          params: { network: "ethereum", pool_address: "0x...", limit: 100, from: 1712700000, to: 1712800000 },
-          note: "from is inclusive, to is exclusive. Results always capped to last 7 days.",
-        },
-      },
-      getTokenMultiPrices: {
-        portfolio_tracking: {
-          description: "Get prices for multiple tokens at once",
-          params: {
-            network: "ethereum",
-            tokens: [
-              "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-              "0xdac17f958d2ee523a2206206994597c13d831ec7",
-              "0x6b175474e89094c44da98b954eedeac495271d0f"
-            ]
-          },
-          note: "Maximum 10 tokens per request",
-        },
-      },
-      search: {
-        by_name: { description: "Find token by name", params: { query: "uniswap" } },
-        by_symbol: { description: "Find token by ticker symbol", params: { query: "USDC" } },
-        by_address: { description: "Find token by contract address", params: { query: "0xa0b8..." } },
-      },
-    },
-    important_fields: {
-      fdv: { name: "Fully Diluted Valuation", description: "Total supply x current price. Use this for market cap comparisons.", example: "fdv: 50000000 means $50M market cap", use_case: "Filtering tokens by market cap range" },
-      volume_usd: { name: "24h Trading Volume (USD)", description: "Total USD value traded in last 24 hours", use_case: "Identifying liquid vs illiquid tokens" },
-      last_price_change_usd_24h: { name: "24h Absolute Price Change", description: "Absolute price change in USD, NOT percentage", example: "0.5 means +$0.50", calculation: "(last_price_change_usd_24h / price_usd) x 100" },
-      transactions: { name: "Total Transaction Count", description: "Cumulative number of swaps since pool creation", use_case: "Gauge trading activity and pool maturity" },
-      inversed: { name: "Inverse Token Pair", description: "When true, flips token0/token1", example: "USDC/WETH -> WETH/USDC", use_case: "Viewing price from opposite perspective" },
-      price_usd: { name: "Current Price (USD)", description: "Real-time token price in USD", note: "Based on most recent pool transaction" },
-      created_at: { name: "Pool Creation Time", format: "ISO 8601 timestamp", example: "2025-10-16T10:00:08Z", use_case: "Finding new pools, calculating pool age" },
-      "amount_0 / amount_1": { name: "Transaction Token Amounts", description: "Positive = tokens added; Negative = removed", use_case: "Identifying buy vs sell transactions" },
-    },
-    common_pitfalls: {
-      external_apis: { issue: "Using external APIs when DexPaprika has data", solution: "Prefer built-in tools", example: "Don't fetch OHLCV elsewhere when getPoolOHLCV exists" },
-      batch_limits: { issue: "Exceeding 10 token limit in getTokenMultiPrices", solution: "Split requests into batches of 10", example: "For 25 tokens: 10 + 10 + 5" },
-      response_size: { issue: "Response too large", solution: "Reduce limit, start with 10", prevention: "Use fields and smaller limits" },
-      ohlcv_empty: { issue: "getPoolOHLCV returns []", cause: "Pool too new", solution: "Use getPoolTransactions for very new pools" },
-      invalid_network: { issue: "Network not found", solution: "Call getNetworks first", tip: "Check network_synonyms" },
-      pagination_confusion: { issue: "Only fetching page 0", solution: "Use cursor or increment page", note: "Page limit 100" },
-      price_change_misinterpretation: { issue: "Assuming 24h change is percentage", reality: "It's absolute USD", calculation: "(change/price_usd)x100" },
-      fdv_vs_mcap: { issue: "FDV vs circulating market cap", clarification: "FDV includes locked/unvested", note: "Circulating may be lower" },
-    },
-    best_practices: {
-      workflow: [
-        "Always call getCapabilities first",
-        "Call getNetworks to validate network IDs",
-        "Use search to find tokens by name/symbol before details",
-        "Start with small limit values and increase if needed",
-        "Cache getNetworks response",
-      ],
-      performance: [
-        "Use getTokenMultiPrices for batch operations",
-        "Client-side caching for networks and DEX lists",
-        "Use cursor pagination for large histories",
-        "Request only necessary OHLCV intervals",
-      ],
-      data_quality: [
-        "Verify pool liquidity before trading",
-        "Cross-reference token data across pools",
-        "Be cautious with pools <24h old",
-        "Check created_at for brand new tokens",
-      ],
-      error_handling: [
-        "Handle empty OHLCV arrays gracefully",
-        "Retry with backoff for rate limits",
-        "Validate network IDs against getNetworks",
-        "Reduce limits if responses are too large",
-      ],
-    },
-    quick_reference: {
-      market_cap_ranges: {
-        nano_cap: "< $1M (extremely high risk)",
-        micro_cap: "$1M - $10M (very high risk)",
-        small_cap: "$10M - $100M (high risk)",
-        mid_cap: "$100M - $1B (moderate risk)",
-        large_cap: "> $1B (lower risk)",
-      },
-      ohlcv_intervals: {
-        scalping: ["1m", "5m"],
-        day_trading: ["5m", "15m", "1h"],
-        swing_trading: ["1h", "6h", "24h"],
-        position_trading: ["24h"],
-      },
-      order_by_options: [
-        "volume_usd - 24h trading volume",
-        "price_usd - Current price",
-        "transactions - Total swap count",
-        "last_price_change_usd_24h - 24h price change",
-        "created_at - Pool creation time",
-      ],
-      max_limits: {
-        pools_per_request: 100,
-        transactions_per_request: 100,
-        ohlcv_data_points: 366,
-        multi_token_prices: 10,
-        transaction_pages: "Unlimited (use cursor)",
-      },
-      supported_dexes: [
-        "Uniswap V2/V3",
-        "PancakeSwap V2/V3",
-        "SushiSwap",
-        "Curve",
-        "Balancer",
-        "And many more - use getNetworkDexes",
-      ],
-    },
-    error_handling: {
-      empty_ohlcv_array: { error_pattern: "getPoolOHLCV returns []", cause: "Pool created too recently", solution: "Use getPoolTransactions", prevention: "Check created_at" },
-      response_too_large: { error_pattern: "Response exceeds size budget", cause: "Too many items", solution: "Reduce limit or paginate" },
-      invalid_network_id: { error_pattern: "Network not found", cause: "Incorrect network", solution: "Call getNetworks", check: "Use network_synonyms" },
-      rate_limit_exceeded: { error_pattern: "Too many requests", solution: "Exponential backoff", prevention: "Use batching where possible" },
-      invalid_time_range: { error_pattern: "Time range exceeds 1 year", cause: "start/end span too large", solution: "Split into multiple requests", note: "Limit 366 data points" },
-      pool_not_found: { error_pattern: "Pool address not found", cause: "Invalid or unknown pool", solution: "Find from getNetworkPools or getTokenPools", tip: "Addresses are network-specific" },
-    },
-    use_case_templates: {
-      find_trending_tokens: {
-        goal: "Find tokens with >100% gains in last 24h on BSC",
-        steps: [
-          "1. getNetworks -> confirm 'bsc' is valid",
-          "2. getNetworkPools(network='bsc', order_by='last_price_change_usd_24h', sort='desc', limit=50)",
-          "3. Filter results where (last_price_change_usd_24h / price_usd) x 100 > 100",
-          "4. For each promising token: getPoolDetails, getPoolOHLCV, getPoolTransactions",
-          "5. Analyze: volume trends, liquidity, holder activity",
-        ],
-      },
-      build_price_alert_bot: {
-        goal: "Alert when ETH price crosses a threshold",
-        steps: [
-          "1. search(query='WETH') -> find WETH token address",
-          "2. getTokenPools(network='ethereum', token_address='0x...') -> find highest liquidity pool",
-          "3. Poll getPoolDetails to check price_usd",
-          "4. Trigger alert on threshold",
-          "5. Optional: getPoolTransactions to see what triggered the move",
-        ],
-      },
-      analyze_new_token_launch: {
-        goal: "Evaluate a token launched recently",
-        steps: [
-          "1. getNetworkPools(order_by='created_at', sort='desc') -> find recent pools",
-          "2. getPoolDetails -> check liquidity depth, token info",
-          "3. getPoolTransactions(limit=100) -> analyze initial trades",
-          "4. Check: whale wallets? mostly buys or sells?",
-          "5. getTokenDetails -> verify fdv",
-        ],
-      },
-      portfolio_rebalancing: {
-        goal: "Check prices of 15 tokens to rebalance portfolio",
-        steps: [
-          "1. Split 15 tokens into batches: [10] + [5]",
-          "2. getTokenMultiPrices for batch1",
-          "3. getTokenMultiPrices for batch2",
-          "4. Calculate portfolio weights",
-          "5. For tokens to trade: getTokenPools -> find best liquidity",
-        ],
-      },
-    },
-    integration_tips: {
-      trading_bots: [
-        "Cache network IDs and DEX lists",
-        "Implement circuit breakers for rate limits",
-        "Store historical OHLCV locally for longer-term charts",
-      ],
-      portfolio_trackers: [
-        "Use getTokenMultiPrices for efficient batch price fetching",
-        "Cache token metadata (symbols, names)",
-        "Poll price updates every 30-60s",
-      ],
-      analytics_dashboards: [
-        "Pre-fetch and cache getNetworks and getNetworkDexes",
-        "Use lazy loading; avoid fetching all pools upfront",
-        "Use transaction data for volume charts",
-      ],
-      token_screeners: [
-        "Fetch pools with high volume",
-        "Client-side filter by fdv for market cap ranges",
-        "Use created_at to separate new vs established tokens",
-        "Combine filters: volume + fdv + price_change",
-      ],
-    },
-    version_history: {
-      "1.1.0": "Added capabilities endpoint and basic workflows; enhanced with detailed examples and guidance",
-      "1.2.0": "Added getNetworkPoolsFilter tool; fixed pagination to 1-indexed; updated stats to 33 networks, 28M+ pools, 25M+ tokens",
-      "1.4.0": "Added filterNetworkTokens and getTopTokens tools; expanded getNetworkPoolsFilter with volume_7d, liquidity params; enriched network/dex responses with volume, txns, pools_count",
-      "1.3.0": "Synced npm package with hosted MCP server; added getCapabilities, getNetworkPoolsFilter; structured error handling; snake_case parameters",
-    },
+    documentation: 'https://docs.dexpaprika.com',
+    agent_skills: 'https://dexpaprika.com/agents/skill.md',
   };
 }
 
-// MCP server instance
-const server = new McpServer({
-  name: 'dexpaprika',
-  version: SERVER_VERSION,
-  description: 'MCP server for accessing DexPaprika API data for decentralized exchanges and tokens',
-});
+// ─────────────────────────────────────────────────────────────────────────────
+// MCP server instance.
+// ─────────────────────────────────────────────────────────────────────────────
+const server = new McpServer(
+  {
+    name: 'dexpaprika',
+    version: SERVER_VERSION,
+  },
+  {
+    instructions: SERVER_INSTRUCTIONS,
+  },
+);
 
-// getNetworks
-server.tool(
+// Helper: register a read tool with rationale + outputSchema + read-only annotations.
+function registerReadTool(name, description, inputShape, handler) {
+  server.registerTool(
+    name,
+    {
+      description,
+      inputSchema: { ...inputShape, rationale: rationaleZod },
+      outputSchema: outputSchemaFor(name),
+      annotations: ANNOTATIONS_READ_ONLY,
+    },
+    handler,
+  );
+}
+
+// ─── getNetworks ─────────────────────────────────────────────────────────────
+registerReadTool(
   'getNetworks',
-  'START HERE: Prefer calling getCapabilities first to see workflows and examples. Then use this to list supported networks.',
+  'START HERE: list all supported blockchain networks with current 24h volume and indexing stats. Prefer calling getCapabilities first to see workflows and synonyms.',
+  {},
   async () => {
     try {
-      const response = await fetchFromAPI('/networks');
-      return formatMcpResponse(response);
+      return jsonText(await fetchFromAPI('/networks'), 'networks');
     } catch (error) {
-      return formatMcpError(error);
+      return errorText(error);
     }
-  }
+  },
 );
 
-// getCapabilities
-server.tool(
+// ─── getCapabilities (local-only, no upstream call) ──────────────────────────
+registerReadTool(
   'getCapabilities',
-  'Return server capabilities, workflow patterns, network synonyms, common pitfalls, and best-practice sequences. Use this to onboard agents quickly.',
+  'Return server capabilities, workflow patterns, network synonyms, common pitfalls, and best-practice sequences. Use this to onboard agents quickly. No parameters required beyond rationale.',
+  {},
   async () => {
     try {
-      const doc = await buildCapabilitiesDocument();
-      return { content: [{ type: "text", text: JSON.stringify(doc, null, 2) }] };
+      return jsonText(buildCapabilitiesDocument());
     } catch (error) {
-      return formatMcpError(error);
+      return errorText(error);
     }
-  }
+  },
 );
 
-// getNetworkDexes
-server.tool(
+// ─── getNetworkDexes ─────────────────────────────────────────────────────────
+registerReadTool(
   'getNetworkDexes',
-  'Get available DEXes on a specific network. TIP: Call getCapabilities for examples. REQUIRED: network. OPTIONAL: page, limit, sort, order_by.',
+  'Get available DEXes on a specific network. REQUIRED: network. OPTIONAL: page, limit, sort_dir/sort, sort_by/order_by.',
   {
     network: z.string().describe("REQUIRED: Network ID from getNetworks (e.g., 'ethereum', 'solana')"),
-    page: z.number().optional().default(1).describe("OPTIONAL: Page number for pagination (default: 1, 1-indexed)"),
-    limit: z.number().optional().default(10).describe("OPTIONAL: Number of items per page (default: 10, max: 100)"),
-    sort: z.enum(['asc', 'desc']).optional().default('desc').describe("OPTIONAL: Sort order (default: 'desc')"),
-    order_by: z.enum(['pool']).optional().describe("OPTIONAL: How to order the returned data")
+    page: z.number().optional().default(1).describe('OPTIONAL: Page number for pagination (default: 1, 1-indexed)'),
+    limit: z.number().optional().default(10).describe('OPTIONAL: Number of items per page (default: 10, max: 100)'),
+    sort_dir: z.enum(['asc', 'desc']).optional().describe("OPTIONAL (preferred): Sort direction, 'asc' or 'desc' (default: 'desc')"),
+    sort: z.enum(['asc', 'desc']).optional().describe('OPTIONAL (deprecated alias of sort_dir): Sort direction'),
+    sort_by: z.enum(['pool']).optional().describe("OPTIONAL (preferred): Field to sort by (only 'pool')"),
+    order_by: z.enum(['pool']).optional().describe('OPTIONAL (deprecated alias of sort_by): Field to sort by'),
   },
-  async ({ network, page, limit, sort, order_by }) => {
+  async (args) => {
     try {
-      let endpoint = `/networks/${network}/dexes?page=${page}&limit=${limit}`;
-      if (sort) endpoint += `&sort=${sort}`;
-      if (order_by) endpoint += `&order_by=${order_by}`;
-      const response = await fetchFromAPI(endpoint);
-      return formatMcpResponse(response);
+      const { network } = args;
+      const page = coercePage(args.page);
+      const limit = args.limit ?? 10;
+      const direction = args.sort_dir ?? args.sort ?? 'desc';
+      const field = args.sort_by ?? args.order_by; // no default — may be undefined
+      let endpoint = `/networks/${network}/dexes?page=${page}&limit=${limit}&sort=${direction}`;
+      if (field) endpoint += `&order_by=${field}`;
+      const upstream = await fetchFromAPI(endpoint);
+      // Upstream ignores limit and returns the full list — slice client-side.
+      if (upstream && Array.isArray(upstream.dexes)) {
+        const total = upstream.dexes.length;
+        const effectivePage = Math.max(1, Number(page ?? 1));
+        const effectiveLimit = Math.max(1, Number(limit ?? 10));
+        const start = (effectivePage - 1) * effectiveLimit;
+        upstream.dexes = upstream.dexes.slice(start, start + effectiveLimit);
+        upstream.page_info = {
+          ...(upstream.page_info ?? {}),
+          limit: effectiveLimit,
+          page: effectivePage,
+          total_items: total,
+          total_pages: Math.max(1, Math.ceil(total / effectiveLimit)),
+        };
+      }
+      return jsonText(upstream);
     } catch (error) {
-      return formatMcpError(error);
+      return errorText(error);
     }
-  }
+  },
 );
 
-// getNetworkPools
-server.tool(
+// ─── getNetworkPools ─────────────────────────────────────────────────────────
+registerReadTool(
   'getNetworkPools',
-  'PRIMARY POOL FUNCTION: Get top liquidity pools on a network. TIP: Call getCapabilities first for parameter examples. REQUIRED: network. OPTIONAL: page, limit, sort, order_by.',
+  'PRIMARY POOL FUNCTION: get top liquidity pools on a network. REQUIRED: network. OPTIONAL: page, limit, sort_dir/sort, sort_by/order_by.',
   {
     network: z.string().describe("REQUIRED: Network ID from getNetworks (e.g., 'ethereum', 'solana')"),
-    page: z.number().optional().default(1).describe("OPTIONAL: Page number for pagination (default: 1, 1-indexed)"),
-    limit: z.number().optional().default(10).describe("OPTIONAL: Number of items per page (default: 10, max: 100)"),
-    sort: z.enum(['asc', 'desc']).optional().default('desc').describe("OPTIONAL: Sort order (default: 'desc')"),
-    order_by: z.enum(['volume_usd', 'price_usd', 'transactions', 'last_price_change_usd_24h', 'created_at']).optional().default('volume_usd').describe("OPTIONAL: Field to order by (default: 'volume_usd')")
+    page: z.number().optional().default(1).describe('OPTIONAL: Page number for pagination (default: 1, 1-indexed)'),
+    limit: z.number().optional().default(10).describe('OPTIONAL: Number of items per page (default: 10, max: 100)'),
+    sort_dir: z.enum(['asc', 'desc']).optional().describe("OPTIONAL (preferred): Sort direction (default: 'desc')"),
+    sort: z.enum(['asc', 'desc']).optional().describe('OPTIONAL (deprecated alias of sort_dir): Sort direction'),
+    sort_by: z.enum(['volume_usd', 'price_usd', 'transactions', 'last_price_change_usd_24h', 'created_at']).optional().describe("OPTIONAL (preferred): Field to sort by (default: 'volume_usd')"),
+    order_by: z.enum(['volume_usd', 'price_usd', 'transactions', 'last_price_change_usd_24h', 'created_at']).optional().describe('OPTIONAL (deprecated alias of sort_by): Field to sort by'),
   },
-  async ({ network, page, limit, sort, order_by }) => {
+  async (args) => {
     try {
-      const endpoint = `/networks/${network}/pools?page=${page}&limit=${limit}&sort=${sort}&order_by=${order_by}`;
-      const response = await fetchFromAPI(endpoint);
-      return formatMcpResponse(response);
+      const { network } = args;
+      const page = coercePage(args.page);
+      const limit = args.limit ?? 10;
+      const direction = args.sort_dir ?? args.sort ?? 'desc';
+      const field = args.sort_by ?? args.order_by ?? 'volume_usd';
+      const endpoint = `/networks/${network}/pools?page=${page}&limit=${limit}&sort=${direction}&order_by=${field}`;
+      return jsonText(await fetchFromAPI(endpoint));
     } catch (error) {
-      return formatMcpError(error);
+      return errorText(error);
     }
-  }
+  },
 );
 
-// getDexPools
-server.tool(
+// ─── getDexPools ─────────────────────────────────────────────────────────────
+registerReadTool(
   'getDexPools',
-  'Get pools from a specific DEX on a network. TIP: See examples in getCapabilities. REQUIRED: network, dex. OPTIONAL: page, limit, sort, order_by.',
+  'Get pools from a specific DEX on a network. REQUIRED: network, dex. OPTIONAL: page, limit, sort_dir/sort, sort_by/order_by.',
   {
     network: z.string().describe("REQUIRED: Network ID from getNetworks (e.g., 'ethereum', 'solana')"),
     dex: z.string().describe("REQUIRED: DEX identifier from getNetworkDexes (e.g., 'uniswap_v3')"),
-    page: z.number().optional().default(1).describe("OPTIONAL: Page number for pagination (default: 1, 1-indexed)"),
-    limit: z.number().optional().default(10).describe("OPTIONAL: Number of items per page (default: 10, max: 100)"),
-    sort: z.enum(['asc', 'desc']).optional().default('desc').describe("OPTIONAL: Sort order (default: 'desc')"),
-    order_by: z.enum(['volume_usd', 'price_usd', 'transactions', 'last_price_change_usd_24h', 'created_at']).optional().default('volume_usd').describe("OPTIONAL: Field to order by (default: 'volume_usd')")
+    page: z.number().optional().default(1).describe('OPTIONAL: Page number for pagination (default: 1, 1-indexed)'),
+    limit: z.number().optional().default(10).describe('OPTIONAL: Number of items per page (default: 10, max: 100)'),
+    sort_dir: z.enum(['asc', 'desc']).optional().describe("OPTIONAL (preferred): Sort direction (default: 'desc')"),
+    sort: z.enum(['asc', 'desc']).optional().describe('OPTIONAL (deprecated alias of sort_dir): Sort direction'),
+    sort_by: z.enum(['volume_usd', 'price_usd', 'transactions', 'last_price_change_usd_24h', 'created_at']).optional().describe("OPTIONAL (preferred): Field to sort by (default: 'volume_usd')"),
+    order_by: z.enum(['volume_usd', 'price_usd', 'transactions', 'last_price_change_usd_24h', 'created_at']).optional().describe('OPTIONAL (deprecated alias of sort_by): Field to sort by'),
   },
-  async ({ network, dex, page, limit, sort, order_by }) => {
+  async (args) => {
     try {
-      const endpoint = `/networks/${network}/dexes/${dex}/pools?page=${page}&limit=${limit}&sort=${sort}&order_by=${order_by}`;
-      const response = await fetchFromAPI(endpoint);
-      return formatMcpResponse(response);
+      const { network, dex } = args;
+      const page = coercePage(args.page);
+      const limit = args.limit ?? 10;
+      const direction = args.sort_dir ?? args.sort ?? 'desc';
+      const field = args.sort_by ?? args.order_by ?? 'volume_usd';
+      const endpoint = `/networks/${network}/dexes/${dex}/pools?page=${page}&limit=${limit}&sort=${direction}&order_by=${field}`;
+      return jsonText(await fetchFromAPI(endpoint));
     } catch (error) {
-      return formatMcpError(error);
+      return errorText(error);
     }
-  }
+  },
 );
 
-// getNetworkPoolsFilter
-server.tool(
+// ─── getNetworkPoolsFilter ───────────────────────────────────────────────────
+registerReadTool(
   'getNetworkPoolsFilter',
-  'Filter pools by volume, liquidity, transactions, and creation time. REQUIRED: network. OPTIONAL: page, limit, volume_24h_min/max, volume_7d_min/max, liquidity_usd_min/max, txns_24h_min, created_after, created_before, sort_by, sort_dir.',
+  'Filter pools by volume, liquidity, transactions, and creation time. REQUIRED: network. OPTIONAL: page, limit, volume_24h_min/max, volume_7d_min/max, liquidity_usd_min/max, txns_24h_min, created_after, created_before, sort_by/order_by, sort_dir/sort.',
   {
     network: z.string().describe("REQUIRED: Network ID from getNetworks (e.g., 'ethereum', 'solana')"),
-    page: z.number().optional().default(1).describe("OPTIONAL: Page number for pagination (default: 1, 1-indexed)"),
-    limit: z.number().optional().default(50).describe("OPTIONAL: Number of items per page (default: 50, max: 100)"),
-    volume_24h_min: z.number().optional().describe("OPTIONAL: Minimum 24h volume in USD"),
-    volume_24h_max: z.number().optional().describe("OPTIONAL: Maximum 24h volume in USD"),
-    volume_7d_min: z.number().optional().describe("OPTIONAL: Minimum 7d volume in USD"),
-    volume_7d_max: z.number().optional().describe("OPTIONAL: Maximum 7d volume in USD"),
-    liquidity_usd_min: z.number().optional().describe("OPTIONAL: Minimum pool liquidity in USD"),
-    liquidity_usd_max: z.number().optional().describe("OPTIONAL: Maximum pool liquidity in USD"),
-    txns_24h_min: z.number().optional().describe("OPTIONAL: Minimum number of transactions in 24h"),
-    created_after: z.number().optional().describe("OPTIONAL: Only pools created after this UNIX timestamp"),
-    created_before: z.number().optional().describe("OPTIONAL: Only pools created before this UNIX timestamp"),
-    sort_by: z.enum(['volume_24h', 'volume_7d', 'volume_30d', 'liquidity', 'txns_24h', 'created_at']).optional().default('volume_24h').describe("OPTIONAL: Field to sort by (default: 'volume_24h')"),
-    sort_dir: z.enum(['asc', 'desc']).optional().default('desc').describe("OPTIONAL: Sort direction (default: 'desc')")
+    page: z.number().optional().default(1).describe('OPTIONAL: Page number for pagination (default: 1, 1-indexed)'),
+    limit: z.number().optional().default(50).describe('OPTIONAL: Number of items per page (default: 50, max: 100)'),
+    volume_24h_min: z.number().optional().describe('OPTIONAL: Minimum 24h volume in USD'),
+    volume_24h_max: z.number().optional().describe('OPTIONAL: Maximum 24h volume in USD'),
+    volume_7d_min: z.number().optional().describe('OPTIONAL: Minimum 7d volume in USD'),
+    volume_7d_max: z.number().optional().describe('OPTIONAL: Maximum 7d volume in USD'),
+    liquidity_usd_min: z.number().optional().describe('OPTIONAL: Minimum pool liquidity in USD'),
+    liquidity_usd_max: z.number().optional().describe('OPTIONAL: Maximum pool liquidity in USD'),
+    txns_24h_min: z.number().optional().describe('OPTIONAL: Minimum number of transactions in 24h'),
+    created_after: z.number().optional().describe('OPTIONAL: Only pools created after this UNIX timestamp'),
+    created_before: z.number().optional().describe('OPTIONAL: Only pools created before this UNIX timestamp'),
+    sort_by: z.enum(['volume_24h', 'volume_7d', 'volume_30d', 'liquidity', 'txns_24h', 'created_at']).optional().describe("OPTIONAL (preferred): Field to sort by (default: 'volume_24h')"),
+    order_by: z.enum(['volume_24h', 'volume_7d', 'volume_30d', 'liquidity', 'txns_24h', 'created_at']).optional().describe('OPTIONAL (deprecated alias of sort_by): Field to sort by'),
+    sort_dir: z.enum(['asc', 'desc']).optional().describe("OPTIONAL (preferred): Sort direction (default: 'desc')"),
+    sort: z.enum(['asc', 'desc']).optional().describe('OPTIONAL (deprecated alias of sort_dir): Sort direction'),
   },
-  async ({ network, page, limit, volume_24h_min, volume_24h_max, volume_7d_min, volume_7d_max, liquidity_usd_min, liquidity_usd_max, txns_24h_min, created_after, created_before, sort_by, sort_dir }) => {
+  async (args) => {
     try {
+      const { network } = args;
+      const page = coercePage(args.page);
+      const limit = args.limit ?? 50;
+      const sort_by = args.sort_by ?? args.order_by ?? 'volume_24h';
+      const sort_dir = args.sort_dir ?? args.sort ?? 'desc';
       let endpoint = `/networks/${network}/pools/filter?page=${page}&limit=${limit}&sort_by=${sort_by}&sort_dir=${sort_dir}`;
-      if (volume_24h_min !== undefined) endpoint += `&volume_24h_min=${volume_24h_min}`;
-      if (volume_24h_max !== undefined) endpoint += `&volume_24h_max=${volume_24h_max}`;
-      if (volume_7d_min !== undefined) endpoint += `&volume_7d_min=${volume_7d_min}`;
-      if (volume_7d_max !== undefined) endpoint += `&volume_7d_max=${volume_7d_max}`;
-      if (liquidity_usd_min !== undefined) endpoint += `&liquidity_usd_min=${liquidity_usd_min}`;
-      if (liquidity_usd_max !== undefined) endpoint += `&liquidity_usd_max=${liquidity_usd_max}`;
-      if (txns_24h_min !== undefined) endpoint += `&txns_24h_min=${txns_24h_min}`;
-      if (created_after !== undefined) endpoint += `&created_after=${created_after}`;
-      if (created_before !== undefined) endpoint += `&created_before=${created_before}`;
-      const response = await fetchFromAPI(endpoint);
-      return formatMcpResponse(response);
+      for (const k of ['volume_24h_min', 'volume_24h_max', 'volume_7d_min', 'volume_7d_max', 'liquidity_usd_min', 'liquidity_usd_max', 'txns_24h_min', 'created_after', 'created_before']) {
+        if (args[k] !== undefined) endpoint += `&${k}=${args[k]}`;
+      }
+      return jsonText(await fetchFromAPI(endpoint));
     } catch (error) {
-      return formatMcpError(error);
+      return errorText(error);
     }
-  }
+  },
 );
 
-// getPoolDetails
-server.tool(
+// ─── getPoolDetails ──────────────────────────────────────────────────────────
+registerReadTool(
   'getPoolDetails',
-  'Get detailed info about a pool. TIP: Use getCapabilities for workflows. REQUIRED: network, pool_address. OPTIONAL: inversed.',
+  'Get detailed info about a pool. REQUIRED: network, pool_address. OPTIONAL: inversed.',
   {
     network: z.string().describe("REQUIRED: Network ID from getNetworks (e.g., 'ethereum', 'solana')"),
     pool_address: z.string().describe("REQUIRED: Pool address or identifier (e.g., '0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640')"),
-    inversed: z.boolean().optional().default(false).describe("OPTIONAL: Whether to invert the price ratio (default: false)")
+    inversed: z.boolean().optional().default(false).describe('OPTIONAL: Whether to invert the price ratio (default: false)'),
   },
   async ({ network, pool_address, inversed }) => {
     try {
       const endpoint = `/networks/${network}/pools/${pool_address}?inversed=${inversed}`;
-      const response = await fetchFromAPI(endpoint);
-      return formatMcpResponse(response);
+      return jsonText(await fetchFromAPI(endpoint));
     } catch (error) {
-      return formatMcpError(error);
+      return errorText(error);
     }
-  }
+  },
 );
 
-// getPoolOHLCV
-server.tool(
+// ─── getPoolOHLCV ────────────────────────────────────────────────────────────
+registerReadTool(
   'getPoolOHLCV',
-  'Get historical price data (OHLCV) for a pool. TIP: See intervals in getCapabilities. REQUIRED: network, pool_address, start. OPTIONAL: end, limit, interval, inversed.',
+  'Get historical price data (OHLCV) for a pool. REQUIRED: network, pool_address, start. OPTIONAL: end, limit, interval, inversed.',
   {
     network: z.string().describe("REQUIRED: Network ID from getNetworks (e.g., 'ethereum', 'solana')"),
-    pool_address: z.string().describe("REQUIRED: Pool address or identifier"),
-    start: z.string().describe("REQUIRED: Start time for historical data (Unix timestamp, RFC3339 timestamp, or yyyy-mm-dd format)"),
-    end: z.string().optional().describe("OPTIONAL: End time for historical data (max 1 year from start)"),
-    limit: z.number().optional().default(1).describe("OPTIONAL: Number of data points to retrieve (default: 1, max: 366)"),
+    pool_address: z.string().describe('REQUIRED: Pool address or identifier'),
+    start: z.string().describe('REQUIRED: Start time for historical data (Unix timestamp, RFC3339 timestamp, or yyyy-mm-dd format)'),
+    end: z.string().optional().describe('OPTIONAL: End time for historical data (max 1 year from start)'),
+    limit: z.number().optional().default(100).describe('OPTIONAL: Number of data points to retrieve (default: 100, max: 366)'),
     interval: z.enum(['1m', '5m', '10m', '15m', '30m', '1h', '6h', '12h', '24h']).optional().default('24h').describe("OPTIONAL: Interval granularity (default: '24h')"),
-    inversed: z.boolean().optional().default(false).describe("OPTIONAL: Whether to invert the price ratio for alternative pair perspective (default: false)")
+    inversed: z.boolean().optional().default(false).describe('OPTIONAL: Whether to invert the price ratio for alternative pair perspective (default: false)'),
   },
   async ({ network, pool_address, start, end, limit, interval, inversed }) => {
     try {
       let endpoint = `/networks/${network}/pools/${pool_address}/ohlcv?start=${encodeURIComponent(start)}&limit=${limit}&interval=${interval}&inversed=${inversed}`;
       if (end) endpoint += `&end=${encodeURIComponent(end)}`;
-      const response = await fetchFromAPI(endpoint);
-      return formatMcpResponse(response);
+      return jsonText(await fetchFromAPI(endpoint), 'ohlcv');
     } catch (error) {
-      return formatMcpError(error);
+      return errorText(error);
     }
-  }
+  },
 );
 
-// getPoolTransactions
-server.tool(
+// ─── getPoolTransactions ─────────────────────────────────────────────────────
+registerReadTool(
   'getPoolTransactions',
-  'Get recent transactions for a pool. TIP: Use cursor for long histories (see getCapabilities). Use from/to for time-range filtering (UNIX timestamps, results capped to last 7 days). REQUIRED: network, pool_address. OPTIONAL: page, limit, cursor, from, to.',
+  'Get recent transactions for a pool. Use from/to for time-range filtering (UNIX epoch seconds, results capped to last 7 days). REQUIRED: network, pool_address. OPTIONAL: page, limit, cursor, from, to.',
   {
     network: z.string().describe("REQUIRED: Network ID from getNetworks (e.g., 'ethereum', 'solana')"),
-    pool_address: z.string().describe("REQUIRED: Pool address or identifier"),
-    page: z.number().optional().default(1).describe("OPTIONAL: Page number for pagination, up to 100 pages (default: 1, 1-indexed)"),
-    limit: z.number().optional().default(10).describe("OPTIONAL: Number of items per page (default: 10, max: 100)"),
-    cursor: z.string().optional().describe("OPTIONAL: Transaction ID used for cursor-based pagination"),
-    from: z.number().optional().describe("OPTIONAL: Filter transactions starting from this UNIX timestamp (inclusive). Results always capped to last 7 days."),
-    to: z.number().optional().describe("OPTIONAL: Filter transactions up to this UNIX timestamp (exclusive). Must be after 'from'.")
+    pool_address: z.string().describe('REQUIRED: Pool address or identifier'),
+    page: z.number().optional().default(1).describe('OPTIONAL: Page number for pagination, up to 100 pages (default: 1, 1-indexed)'),
+    limit: z.number().optional().default(10).describe('OPTIONAL: Number of items per page (default: 10, max: 100)'),
+    cursor: z.string().optional().describe('OPTIONAL: Transaction ID used for cursor-based pagination'),
+    from: z.number().optional().describe('OPTIONAL: Filter transactions starting from this UNIX timestamp (inclusive). Results always capped to last 7 days.'),
+    to: z.number().optional().describe("OPTIONAL: Filter transactions up to this UNIX timestamp (exclusive). Must be after 'from'."),
   },
-  async ({ network, pool_address, page, limit, cursor, from, to }) => {
+  async (args) => {
     try {
+      const { network, pool_address, cursor, from, to } = args;
+      const page = coercePage(args.page);
+      const limit = args.limit ?? 10;
       let endpoint = `/networks/${network}/pools/${pool_address}/transactions?page=${page}&limit=${limit}`;
       if (cursor) endpoint += `&cursor=${encodeURIComponent(cursor)}`;
       if (from !== undefined) endpoint += `&from=${from}`;
       if (to !== undefined) endpoint += `&to=${to}`;
-      const response = await fetchFromAPI(endpoint);
-      return formatMcpResponse(response);
+      return jsonText(await fetchFromAPI(endpoint));
     } catch (error) {
-      return formatMcpError(error);
+      return errorText(error);
     }
-  }
+  },
 );
 
-// getTokenDetails
-server.tool(
+// ─── getTokenDetails ─────────────────────────────────────────────────────────
+registerReadTool(
   'getTokenDetails',
-  'Get detailed information about a token. TIP: Normalize networks via getCapabilities synonyms. REQUIRED: network, token_address.',
+  'Get detailed information about a token. REQUIRED: network, token_address.',
   {
     network: z.string().describe("REQUIRED: Network ID from getNetworks (e.g., 'ethereum', 'solana')"),
-    token_address: z.string().describe("REQUIRED: Token contract address (e.g., 'JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN' for Jupiter on Solana)")
+    token_address: z.string().describe("REQUIRED: Token contract address (e.g., 'JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN' for Jupiter on Solana)"),
   },
   async ({ network, token_address }) => {
     try {
       const endpoint = `/networks/${network}/tokens/${token_address}`;
-      const response = await fetchFromAPI(endpoint);
-      return formatMcpResponse(response);
+      return jsonText(await fetchFromAPI(endpoint));
     } catch (error) {
-      return formatMcpError(error);
+      return errorText(error);
     }
-  }
-);
-
-// getTokenPools
-server.tool(
-  'getTokenPools',
-  'Get liquidity pools containing a token. TIP: Use fields to reduce payloads. REQUIRED: network, token_address. OPTIONAL: page, limit, sort, order_by, reorder, address.',
-  {
-    network: z.string().describe("REQUIRED: Network ID from getNetworks (e.g., 'ethereum', 'solana')"),
-    token_address: z.string().describe("REQUIRED: Token contract address"),
-    page: z.number().optional().default(1).describe("OPTIONAL: Page number for pagination (default: 1, 1-indexed)"),
-    limit: z.number().optional().default(10).describe("OPTIONAL: Number of items per page (default: 10, max: 100)"),
-    sort: z.enum(['asc', 'desc']).optional().default('desc').describe("OPTIONAL: Sort order (default: 'desc')"),
-    order_by: z.enum(['volume_usd', 'price_usd', 'transactions', 'last_price_change_usd_24h', 'created_at']).optional().default('volume_usd').describe("OPTIONAL: Field to order by (default: 'volume_usd')"),
-    reorder: z.boolean().optional().describe("OPTIONAL: If true, reorders the pool so that the specified token becomes the primary token for all metrics"),
-    address: z.string().optional().describe("OPTIONAL: Filter pools that contain this additional token address")
   },
-  async ({ network, token_address, page, limit, sort, order_by, reorder, address }) => {
-    try {
-      let endpoint = `/networks/${network}/tokens/${token_address}/pools?page=${page}&limit=${limit}&sort=${sort}&order_by=${order_by}`;
-      if (reorder !== undefined) endpoint += `&reorder=${reorder}`;
-      if (address) endpoint += `&address=${encodeURIComponent(address)}`;
-      const response = await fetchFromAPI(endpoint);
-      return formatMcpResponse(response);
-    } catch (error) {
-      return formatMcpError(error);
-    }
-  }
 );
 
-// getTokenMultiPrices
-server.tool(
-  'getTokenMultiPrices',
-  'Get batched prices for multiple tokens. TIP: Max 10; join into a single comma-separated tokens string. REQUIRED: network, tokens.',
+// ─── getTokenPools ───────────────────────────────────────────────────────────
+registerReadTool(
+  'getTokenPools',
+  'Get liquidity pools containing a token. REQUIRED: network, token_address. OPTIONAL: page, limit, sort_dir/sort, sort_by/order_by, inversed/reorder, paired_token_address/address.',
   {
     network: z.string().describe("REQUIRED: Network ID from getNetworks (e.g., 'ethereum', 'solana')"),
-    tokens: z.array(z.string()).nonempty().describe("REQUIRED: Up to 10 token addresses. Will be serialized as a single comma-separated query param (?tokens=a,b,c).")
+    token_address: z.string().describe('REQUIRED: Token contract address'),
+    page: z.number().optional().default(1).describe('OPTIONAL: Page number for pagination (default: 1, 1-indexed)'),
+    limit: z.number().optional().default(10).describe('OPTIONAL: Number of items per page (default: 10, max: 100)'),
+    sort_dir: z.enum(['asc', 'desc']).optional().describe("OPTIONAL (preferred): Sort direction (default: 'desc')"),
+    sort: z.enum(['asc', 'desc']).optional().describe('OPTIONAL (deprecated alias of sort_dir): Sort direction'),
+    sort_by: z.enum(['volume_usd', 'price_usd', 'transactions', 'last_price_change_usd_24h', 'created_at']).optional().describe("OPTIONAL (preferred): Field to sort by (default: 'volume_usd')"),
+    order_by: z.enum(['volume_usd', 'price_usd', 'transactions', 'last_price_change_usd_24h', 'created_at']).optional().describe('OPTIONAL (deprecated alias of sort_by): Field to sort by'),
+    inversed: z.boolean().optional().describe("OPTIONAL (preferred): Flip the pool's pair perspective so the specified token becomes primary"),
+    reorder: z.boolean().optional().describe('OPTIONAL (deprecated alias of inversed): Reorder the pool'),
+    paired_token_address: z.string().optional().describe('OPTIONAL (preferred): Filter pools that also contain this token address'),
+    address: z.string().optional().describe('OPTIONAL (deprecated alias of paired_token_address): Additional token address filter'),
+  },
+  async (args) => {
+    try {
+      const { network, token_address } = args;
+      const page = coercePage(args.page);
+      const limit = args.limit ?? 10;
+      const direction = args.sort_dir ?? args.sort ?? 'desc';
+      const field = args.sort_by ?? args.order_by ?? 'volume_usd';
+      const flip = args.inversed ?? args.reorder; // may be undefined
+      const paired = args.paired_token_address ?? args.address; // may be undefined
+      let endpoint = `/networks/${network}/tokens/${token_address}/pools?page=${page}&limit=${limit}&sort=${direction}&order_by=${field}`;
+      if (flip !== undefined) endpoint += `&reorder=${flip}`;
+      if (paired) endpoint += `&address=${encodeURIComponent(paired)}`;
+      return jsonText(await fetchFromAPI(endpoint));
+    } catch (error) {
+      return errorText(error);
+    }
+  },
+);
+
+// ─── getTokenMultiPrices (hand-built response, not jsonText) ──────────────────
+registerReadTool(
+  'getTokenMultiPrices',
+  'Get batched prices for multiple tokens. Max 10 tokens per call, same network. REQUIRED: network, tokens.',
+  {
+    network: z.string().describe('REQUIRED: Network ID from getNetworks'),
+    tokens: z.array(z.string()).min(1).max(10).describe('REQUIRED: Up to 10 token contract addresses on the same network.'),
   },
   async ({ network, tokens }) => {
     try {
       if (tokens.length > 10) {
-        const error = buildErrorResponse(
-          ErrorCodes.DP400_TOO_MANY_TOKENS,
-          "Too many tokens in batch request",
-          false,
-          "Split request into batches of max 10 tokens each",
-          `getTokenMultiPrices('ethereum', ['0x123...', '0x456...']) // max 10`,
-          { limit: 10, provided: tokens.length }
-        );
-        return formatMcpResponse(error);
+        return jsonText({
+          error: 'Too many tokens',
+          message: 'getTokenMultiPrices accepts at most 10 tokens per call.',
+          provided: tokens.length,
+          limit: 10,
+        });
       }
       const joined = tokens.join(',');
-      const endpoint = `/networks/${network}/multi/prices?tokens=${encodeURIComponent(joined)}`;
-      const response = await fetchFromAPI(endpoint);
-      return formatMcpResponse(response);
+      const upstream = await fetchFromAPI(`/networks/${network}/multi/prices?tokens=${encodeURIComponent(joined)}`);
+      const prices = Array.isArray(upstream) ? upstream : [];
+      // Upstream silently drops tokens it can't price — surface them so callers
+      // can detect partial failures without a set-difference of their own.
+      const returnedIds = new Set(prices.map((p) => String(p?.id ?? '').toLowerCase()));
+      const missing_tokens = tokens.filter((t) => !returnedIds.has(t.toLowerCase()));
+      const enriched = { prices, missing_tokens };
+      return {
+        content: [{ type: 'text', text: JSON.stringify(enriched) }],
+        structuredContent: enriched,
+      };
     } catch (error) {
-      return formatMcpError(error);
+      return errorText(error);
     }
-  }
+  },
 );
 
-// filterNetworkTokens
-server.tool(
+// ─── filterNetworkTokens ─────────────────────────────────────────────────────
+registerReadTool(
   'filterNetworkTokens',
-  'Filter tokens by volume, liquidity, FDV, transactions, and creation time. REQUIRED: network. OPTIONAL: page, limit, volume_24h_min/max, liquidity_usd_min, fdv_min/max, txns_24h_min, created_after/before, sort_by, sort_dir.',
+  'Filter tokens by volume, liquidity, FDV, transactions, and creation time. REQUIRED: network. OPTIONAL: page, limit, volume_24h_min/max, liquidity_usd_min, fdv_min/max, txns_24h_min, created_after/before, sort_by/order_by, sort_dir/sort.',
   {
     network: z.string().describe("REQUIRED: Network ID from getNetworks (e.g., 'ethereum', 'solana')"),
-    page: z.number().optional().default(1).describe("OPTIONAL: Page number for pagination (default: 1, 1-indexed)"),
-    limit: z.number().optional().default(50).describe("OPTIONAL: Number of items per page (default: 50, max: 100)"),
-    volume_24h_min: z.number().optional().describe("OPTIONAL: Minimum 24h volume in USD"),
-    volume_24h_max: z.number().optional().describe("OPTIONAL: Maximum 24h volume in USD"),
-    liquidity_usd_min: z.number().optional().describe("OPTIONAL: Minimum token liquidity in USD"),
-    fdv_min: z.number().optional().describe("OPTIONAL: Minimum fully diluted valuation in USD"),
-    fdv_max: z.number().optional().describe("OPTIONAL: Maximum fully diluted valuation in USD"),
-    txns_24h_min: z.number().optional().describe("OPTIONAL: Minimum number of transactions in 24h"),
-    created_after: z.number().optional().describe("OPTIONAL: Only tokens created after this UNIX timestamp"),
-    created_before: z.number().optional().describe("OPTIONAL: Only tokens created before this UNIX timestamp"),
-    sort_by: z.enum(['volume_24h', 'volume_7d', 'volume_30d', 'liquidity_usd', 'txns_24h', 'created_at', 'fdv']).optional().default('volume_24h').describe("OPTIONAL: Field to sort by (default: 'volume_24h')"),
-    sort_dir: z.enum(['asc', 'desc']).optional().default('desc').describe("OPTIONAL: Sort direction (default: 'desc')")
+    page: z.number().optional().default(1).describe('OPTIONAL: Page number for pagination (default: 1, 1-indexed)'),
+    limit: z.number().optional().default(50).describe('OPTIONAL: Number of items per page (default: 50, max: 100)'),
+    volume_24h_min: z.number().optional().describe('OPTIONAL: Minimum 24h volume in USD'),
+    volume_24h_max: z.number().optional().describe('OPTIONAL: Maximum 24h volume in USD'),
+    liquidity_usd_min: z.number().optional().describe('OPTIONAL: Minimum token liquidity in USD'),
+    fdv_min: z.number().optional().describe('OPTIONAL: Minimum fully diluted valuation in USD'),
+    fdv_max: z.number().optional().describe('OPTIONAL: Maximum fully diluted valuation in USD'),
+    txns_24h_min: z.number().optional().describe('OPTIONAL: Minimum number of transactions in 24h'),
+    created_after: z.number().optional().describe('OPTIONAL: Only tokens created after this UNIX timestamp'),
+    created_before: z.number().optional().describe('OPTIONAL: Only tokens created before this UNIX timestamp'),
+    sort_by: z.enum(['volume_24h', 'volume_7d', 'volume_30d', 'liquidity_usd', 'txns_24h', 'created_at', 'fdv']).optional().describe("OPTIONAL (preferred): Field to sort by (default: 'volume_24h')"),
+    order_by: z.enum(['volume_24h', 'volume_7d', 'volume_30d', 'liquidity_usd', 'txns_24h', 'created_at', 'fdv']).optional().describe('OPTIONAL (deprecated alias of sort_by): Field to sort by'),
+    sort_dir: z.enum(['asc', 'desc']).optional().describe("OPTIONAL (preferred): Sort direction (default: 'desc')"),
+    sort: z.enum(['asc', 'desc']).optional().describe('OPTIONAL (deprecated alias of sort_dir): Sort direction'),
   },
-  async ({ network, page, limit, volume_24h_min, volume_24h_max, liquidity_usd_min, fdv_min, fdv_max, txns_24h_min, created_after, created_before, sort_by, sort_dir }) => {
+  async (args) => {
     try {
+      const { network } = args;
+      const page = coercePage(args.page);
+      const limit = args.limit ?? 50;
+      const sort_by = args.sort_by ?? args.order_by ?? 'volume_24h';
+      const sort_dir = args.sort_dir ?? args.sort ?? 'desc';
       let endpoint = `/networks/${network}/tokens/filter?page=${page}&limit=${limit}&sort_by=${sort_by}&sort_dir=${sort_dir}`;
-      if (volume_24h_min !== undefined) endpoint += `&volume_24h_min=${volume_24h_min}`;
-      if (volume_24h_max !== undefined) endpoint += `&volume_24h_max=${volume_24h_max}`;
-      if (liquidity_usd_min !== undefined) endpoint += `&liquidity_usd_min=${liquidity_usd_min}`;
-      if (fdv_min !== undefined) endpoint += `&fdv_min=${fdv_min}`;
-      if (fdv_max !== undefined) endpoint += `&fdv_max=${fdv_max}`;
-      if (txns_24h_min !== undefined) endpoint += `&txns_24h_min=${txns_24h_min}`;
-      if (created_after !== undefined) endpoint += `&created_after=${created_after}`;
-      if (created_before !== undefined) endpoint += `&created_before=${created_before}`;
-      const response = await fetchFromAPI(endpoint);
-      return formatMcpResponse(response);
+      for (const k of ['volume_24h_min', 'volume_24h_max', 'liquidity_usd_min', 'fdv_min', 'fdv_max', 'txns_24h_min', 'created_after', 'created_before']) {
+        if (args[k] !== undefined) endpoint += `&${k}=${args[k]}`;
+      }
+      return jsonText(await fetchFromAPI(endpoint));
     } catch (error) {
-      return formatMcpError(error);
+      return errorText(error);
     }
-  }
+  },
 );
 
-// getTopTokens
-server.tool(
+// ─── getTopTokens ────────────────────────────────────────────────────────────
+registerReadTool(
   'getTopTokens',
-  'Get top tokens on a network ranked by volume, price, liquidity, or activity. Each token includes enriched metadata and multi-timeframe metrics (24h, 1h, 5m). REQUIRED: network. OPTIONAL: page, limit, order_by, sort.',
+  'Get top tokens on a network ranked by volume, price, liquidity, or activity. Each token includes enriched metadata and multi-timeframe metrics (24h, 1h, 5m). REQUIRED: network. OPTIONAL: page, limit, sort_by/order_by, sort_dir/sort.',
   {
     network: z.string().describe("REQUIRED: Network ID from getNetworks (e.g., 'ethereum', 'solana')"),
-    page: z.number().optional().default(1).describe("OPTIONAL: Page number for pagination (default: 1, 1-indexed)"),
-    limit: z.number().optional().default(50).describe("OPTIONAL: Number of items per page (default: 50, max: 100)"),
-    order_by: z.enum(['volume_24h', 'price_usd', 'liquidity_usd', 'txns', 'price_change']).optional().default('volume_24h').describe("OPTIONAL: Field to order by (default: 'volume_24h')"),
-    sort: z.enum(['asc', 'desc']).optional().default('desc').describe("OPTIONAL: Sort direction (default: 'desc')")
+    page: z.number().optional().default(1).describe('OPTIONAL: Page number for pagination (default: 1, 1-indexed)'),
+    limit: z.number().optional().default(50).describe('OPTIONAL: Number of items per page (default: 50, max: 100)'),
+    sort_by: z.enum(['volume_24h', 'price_usd', 'liquidity_usd', 'txns', 'price_change']).optional().describe("OPTIONAL (preferred): Field to sort by (default: 'volume_24h')"),
+    order_by: z.enum(['volume_24h', 'price_usd', 'liquidity_usd', 'txns', 'price_change']).optional().describe('OPTIONAL (deprecated alias of sort_by): Field to sort by'),
+    sort_dir: z.enum(['asc', 'desc']).optional().describe("OPTIONAL (preferred): Sort direction (default: 'desc')"),
+    sort: z.enum(['asc', 'desc']).optional().describe('OPTIONAL (deprecated alias of sort_dir): Sort direction'),
   },
-  async ({ network, page, limit, order_by, sort }) => {
+  async (args) => {
     try {
-      const endpoint = `/networks/${network}/tokens/top?page=${page}&limit=${limit}&order_by=${order_by}&sort=${sort}`;
-      const response = await fetchFromAPI(endpoint);
-      return formatMcpResponse(response);
+      const { network } = args;
+      const page = coercePage(args.page);
+      const limit = args.limit ?? 50;
+      const direction = args.sort_dir ?? args.sort ?? 'desc';
+      const field = args.sort_by ?? args.order_by ?? 'volume_24h';
+      const endpoint = `/networks/${network}/tokens/top?page=${page}&limit=${limit}&order_by=${field}&sort=${direction}`;
+      return jsonText(await fetchFromAPI(endpoint));
     } catch (error) {
-      return formatMcpError(error);
+      return errorText(error);
     }
-  }
+  },
 );
 
-// search
-server.tool(
+// ─── search (cross-network) ──────────────────────────────────────────────────
+registerReadTool(
   'search',
-  "Search across ALL networks for tokens, pools, and DEXes by name, symbol, or address. Good starting point when you don't know the specific network. Returns matching tokens, pools, and DEXes. REQUIRED: query. No optional parameters.",
+  "Search across ALL networks for tokens, pools, and DEXes by name, symbol, or address. Good starting point when you don't know the specific network. REQUIRED: query. OPTIONAL: limit (per-category, applied client-side).",
   {
-    query: z.string().describe("REQUIRED: Search term (e.g., 'uniswap', 'bitcoin', 'ethereum', or a token address)")
+    query: z.string().describe("REQUIRED: Search term (e.g., 'uniswap', 'bitcoin', or a token address)"),
+    limit: z.number().optional().describe('OPTIONAL: Max results per category (tokens/pools/dexes), applied client-side'),
   },
-  async ({ query }) => {
+  async ({ query, limit }) => {
     try {
-      const endpoint = `/search?query=${encodeURIComponent(query)}`;
-      const response = await fetchFromAPI(endpoint);
-      return formatMcpResponse(response);
+      const upstream = await fetchFromAPI(`/search?query=${encodeURIComponent(query)}`);
+      // Rename dex_id -> factory_id in pools[] for consistency with getPoolDetails.
+      if (upstream && Array.isArray(upstream.pools)) {
+        upstream.pools = upstream.pools.map((p) => {
+          if (p && typeof p === 'object' && 'dex_id' in p) {
+            const { dex_id, ...rest } = p;
+            return { ...rest, factory_id: dex_id };
+          }
+          return p;
+        });
+      }
+      // Client-side per-category limit. Never sent upstream.
+      if (limit !== undefined && upstream && typeof upstream === 'object') {
+        const n = Math.max(1, Math.floor(limit));
+        for (const key of ['tokens', 'pools', 'dexes']) {
+          if (Array.isArray(upstream[key])) upstream[key] = upstream[key].slice(0, n);
+        }
+      }
+      return jsonText(upstream);
     } catch (error) {
-      return formatMcpError(error);
+      return errorText(error);
     }
-  }
+  },
 );
 
-// getStats
-server.tool(
+// ─── getStats ────────────────────────────────────────────────────────────────
+registerReadTool(
   'getStats',
-  'Get high-level statistics about the DexPaprika ecosystem: total networks, DEXes, pools, and tokens available. Provides a quick overview of the platform\'s coverage. No parameters required.',
+  'Get high-level statistics about the DexPaprika ecosystem: total chains, factories, pools, and tokens indexed. No parameters required beyond rationale.',
+  {},
   async () => {
     try {
-      const response = await fetchFromAPI('/stats');
-      return formatMcpResponse(response);
+      return jsonText(await fetchFromAPI('/stats'));
     } catch (error) {
-      return formatMcpError(error);
+      return errorText(error);
     }
-  }
+  },
 );
 
-// Start the server
+// ─── submitFeedback (17th tool, NO rationale, write annotation) ──────────────
+// stdio has no D1; we degrade to a structured ack instead of a DB INSERT.
+server.registerTool(
+  'submitFeedback',
+  {
+    description:
+      "Call this when you got stuck, when a tool's response was unexpected, when you needed information that wasn't available, or when something didn't behave as documented. Low friction — submit even partial feedback. We read every submission. Does NOT require a 'rationale' field; the goal/expected/observed fields below ARE the rationale.",
+    inputSchema: {
+      goal: z.string().min(10).max(500).describe('REQUIRED. What you were trying to accomplish (10-500 chars).'),
+      attempted_tools: z.array(z.string()).optional().describe('OPTIONAL. Tools you tried before getting stuck.'),
+      blocked_at: z.string().optional().describe('OPTIONAL. Where exactly you got blocked.'),
+      expected: z.string().max(500).optional().describe('OPTIONAL. What you expected to happen (max 500 chars).'),
+      observed: z.string().max(500).optional().describe('OPTIONAL. What actually happened (max 500 chars).'),
+      severity: z.enum(['blocker', 'major', 'minor', 'nit']).optional().default('minor').describe("OPTIONAL. Impact severity (default: 'minor')."),
+    },
+    outputSchema: outputSchemaFor('submitFeedback'),
+    annotations: ANNOTATIONS_WRITE_FEEDBACK,
+  },
+  async ({ severity }) => {
+    // No D1 / no analytics sink in the self-host build. Accept and acknowledge.
+    const ack = {
+      ok: true,
+      tracking_id: null,
+      message: 'Thanks. This self-host build does not persist feedback; please open an issue at https://github.com/coinpaprika/dexpaprika-mcp for anything actionable.',
+      severity: severity ?? 'minor',
+    };
+    return jsonText(ack);
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Start the server over stdio.
+// ─────────────────────────────────────────────────────────────────────────────
 async function main() {
   try {
     const transport = new StdioServerTransport();
     await server.connect(transport);
-    console.error('DexPaprika MCP server is running...');
+    console.error('DexPaprika MCP server (v2.0.0) is running...');
   } catch (error) {
     console.error('Failed to start server:', error);
     process.exit(1);


### PR DESCRIPTION
## What

Brings the self-host stdio npm package up to **1:1 contract parity with the hosted worker** at `mcp.dexpaprika.com` (v2.0.0). Only the transport differs now (stdio vs HTTP) — tools, parameters, aliases, synonym resolution, sort normalization, output schemas, server instructions and version all match.

## Why

The package had drifted badly from the hosted server. Published `1.5.0` reports `1.3.0` at runtime, while the worker is `2.0.0`. Concretely, a self-host user got:
- **Broken synonyms** — `getCapabilities` advertised `eth`/`matic`/etc., but the package never normalized them, so they 404'd against the raw API (the worker resolves them at its edge).
- **Half the sort vocabulary** — list tools accepted only `sort`/`order_by`, silently dropping the canonical `sort_dir`/`sort_by` the hosted instructions tell agents to use.
- 16 tools instead of 17, no `structuredContent`/`outputSchema`, a stale capabilities doc ("33 networks"), no server `instructions`.

## Changes

- **SDK** `^1.4.1` → `^1.29.0`; **version** → `2.0.0`.
- **Synonym resolution** — ported the worker's 35-network map + `normalizeNetwork`/`normalizeNetworkPath`, hooked at the single `fetchFromAPI` chokepoint, so `eth`→`ethereum` etc. resolve at the wire. Same map drives `getCapabilities.network_synonyms`.
- **Sort params** — canonical `sort_dir`/`sort_by` aliases on the 5 legacy-emitting tools; legacy `sort`/`order_by` aliases on the 2 filter tools. Canonical wins; each tool's existing wire param is preserved. `getTokenPools` gains `inversed`/`paired_token_address`. `page=0`→`1` coercion.
- **`rationale`** (20–500 chars) required on every read tool (accepted and discarded — no analytics sink in self-host); `submitFeedback` excepted.
- **Output contract** — every tool migrated to `registerTool` with `inputSchema`/`outputSchema`; dual `content[0].text` + `structuredContent`; array tools wrap under named keys; `getTokenMultiPrices` → `{prices, missing_tokens}`. The `{data, meta}` wrapper is dropped.
- **`getCapabilities`** rewritten to the worker's lean shape (17 tools, 35 networks, stats, `agent_skills`); **`submitFeedback`** added as the 17th tool; server **`instructions`** added.

## ⚠️ Breaking (2.0.0) — see CHANGELOG

The `{ data, meta }` response wrapper is gone (payload returned directly + as `structuredContent`); array tools wrap under named keys; `rationale` is now required on read tools; SDK floor is `^1.29.0`.

## Verification

Tested against the live API via the real MCP client over stdio (not code-reading):
- **All 17 tools** return cleanly with non-empty `structuredContent` under SDK 1.29 strict output validation.
- **Tool surface is byte-identical to the live hosted server** (same 17 names).
- Synonyms resolve (`eth`→ethereum, `matic`→polygon); canonical vs legacy sort produce **identical ordering**; invalid network → clean structured error; `getTokenMultiPrices` reshape + `missing_tokens` work.
- `getCapabilities` + `instructions` + the synonym map deep-compared byte-for-byte against the worker.
- Adversarial multi-dimension review of the full diff (per-tool URL fidelity, output schemas, capabilities/instructions, regression safety) — **no confirmed issues**.

## Notes / worker-side follow-ups found during the port

These are in the **hosted worker** (not this PR), surfaced while matching it:
- `filterNetworkTokens` declares a `results` output array but the API returns rows under `data` (+ a `query` echo). SDK 1.29 strict validation flags it; here the schema key is optional + outer `.passthrough()` so tokens still flow. The worker's declared schema is worth fixing to `data`.
- The worker sends `page=0` raw despite its own docs saying "treated as page=1"; this package coerces (matches the documented contract).
- Worker `getCapabilities` stats (29M/31M) disagree with its `server-meta` display strings (31M/33M).

## Heads up

Merging does **not** publish — `dexpaprika-mcp` is unscoped, so reaching `npx` users needs a separate `npm publish` (maintainer + 2FA) after merge.
