### PR TITLE
Add CI (Node matrix + MCP smoke test)

### DIFF
--- a/.github/smoke.mjs
+++ b/.github/smoke.mjs
@@ -1,0 +1,37 @@
+// CI smoke test: boot the stdio MCP server and verify the MCP handshake +
+// tool registry over a real client. Fully offline — `initialize` and
+// `tools/list` make no upstream API calls, so this is deterministic and not
+// subject to live-data flakiness or rate limits.
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const MIN_TOOLS = 14; // lenient floor (package has 16 on v1.x, 17 on v2.x)
+const CORE_TOOLS = ['getNetworks', 'getNetworkPools', 'getCapabilities'];
+
+const transport = new StdioClientTransport({ command: 'node', args: ['src/index.js'] });
+const client = new Client({ name: 'ci-smoke', version: '1.0.0' }, { capabilities: {} });
+
+let failed = false;
+const fail = (msg) => { console.error(`FAIL: ${msg}`); failed = true; };
+
+try {
+  await client.connect(transport);
+
+  const info = client.getServerVersion?.() ?? {};
+  console.log(`server: ${info.name ?? '?'} v${info.version ?? '?'}`);
+
+  const { tools } = await client.listTools();
+  console.log(`tools (${tools.length}): ${tools.map((t) => t.name).sort().join(', ')}`);
+
+  if (tools.length < MIN_TOOLS) fail(`expected >= ${MIN_TOOLS} tools, got ${tools.length}`);
+
+  const missing = CORE_TOOLS.filter((n) => !tools.some((t) => t.name === n));
+  if (missing.length) fail(`missing core tools: ${missing.join(', ')}`);
+} catch (err) {
+  fail(`MCP handshake threw: ${err?.message ?? err}`);
+} finally {
+  await client.close().catch(() => {});
+}
+
+if (failed) process.exit(1);
+console.log('SMOKE OK');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Least privilege: CI only reads the repo and runs tests.
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test (node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['18', '20', '22']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Syntax check
+        run: node --check src/index.js
+
+      - name: Build
+        run: npm run build
+
+      - name: MCP smoke (initialize + tools/list)
+        run: node .github/smoke.mjs


### PR DESCRIPTION
## What
Adds GitHub Actions CI to the repo (it had none).

## Why
With no CI, a broken build, a syntax error, or a server that fails to start could land on `main` and ship to npm unnoticed — exactly how a sibling repo's CI sat red for weeks before anyone noticed. This gives every push and PR a green/red signal.

## The pipeline
On push to `main` and on every PR:
- **Node 18 / 20 / 22** matrix
- `npm ci` (with `setup-node` npm cache — relies on the committed `package-lock.json`)
- `node --check src/index.js` (syntax)
- `npm run build`
- **MCP smoke** (`.github/smoke.mjs`): boots the stdio server over a real MCP client, runs `initialize` + `tools/list`, asserts the handshake works and core tools (`getNetworks`, `getNetworkPools`, `getCapabilities`) are registered. **Fully offline** — no upstream API calls, so it's deterministic (no live-data flakiness / rate limits).

`GITHUB_TOKEN` is pinned to `contents: read` (least privilege).

## Verified
Ran the smoke locally against current `main`: boots `dexpaprika v1.3.0`, lists 16 tools, `SMOKE OK`, exit 0. The `>= 14` tool floor also passes the v2.0.0 branch (17 tools), so this won't break either line.

Note: once this is on `main`, updating an open PR's branch (e.g. #18) will make CI run on it too.
