### PR TITLE
fix: add npm package metadata links

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,14 @@
   ],
   "author": "",
   "license": "MIT",
+  "homepage": "https://github.com/coinpaprika/dexpaprika-mcp#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/coinpaprika/dexpaprika-mcp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/coinpaprika/dexpaprika-mcp/issues"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "node-fetch": "^3.3.2",


### PR DESCRIPTION
## Summary
- add standard npm `homepage`, `repository`, and `bugs` metadata to `package.json`
- point package consumers and registry tooling back to the public DexPaprika MCP source and issue tracker

## Reproduction
Current published metadata only exposes name/version:

```sh
npm view dexpaprika-mcp@1.5.0 name version homepage repository bugs --json
```

Observed output:

```json
{
  "name": "dexpaprika-mcp",
  "version": "1.5.0"
}
```

## Verification
- `npm install --ignore-scripts --no-audit --no-fund`
- `npm run build`
- `npm test`
