### PR TITLE
Fix 410s: migrate pool/token list+filter tools to /search (npm)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the DexPaprika MCP Server will be documented in this file.
 
+## [2.1.0] - 2026-06-30
+
+Migrate the pool and token list/filter tools to the unified search endpoints. DexPaprika removed `/networks/{network}/pools`, `/networks/{network}/pools/filter`, `/networks/{network}/tokens/top`, and `/networks/{network}/tokens/filter` (HTTP 410), so `getNetworkPools`, `getNetworkPoolsFilter`, `getTopTokens`, and `filterNetworkTokens` were erroring until this release.
+
+### Breaking changes
+
+- **`getNetworkPools`, `getNetworkPoolsFilter`, `getTopTokens`, and `filterNetworkTokens` now return rows under `results`** (was `pools` / `tokens` / `data`) with cursor pagination (`has_next_page` + `next_cursor`) instead of `page_info` and page numbers. The `page` parameter is replaced by `cursor`. Rows use the canonical field names (`volume_usd_24h`, `txns_24h`, `liquidity_usd`, `fdv_usd`, `price_change_percentage_24h`). This mirrors the upstream API change and is unavoidable.
+- **`getTopTokens` no longer supports ordering by price**: the search endpoint rejects it, so a supplied `price_usd` falls back to `volume_usd_24h`.
+
+### Changed
+
+- `getNetworkPools` and `getNetworkPoolsFilter` now proxy `/networks/{network}/pools/search`; `getTopTokens` and `filterNetworkTokens` proxy `/networks/{network}/tokens/search`. Tool names are unchanged for client back-compat.
+- Legacy sort-field values (`volume_usd`, `transactions`, `last_price_change_usd_24h`, `volume_24h`, `liquidity`, ...) and legacy filter param names (`volume_24h_min` → `volume_usd_24h_min`, ...) are auto-mapped to the canonical search names, so existing callers keep working. A shared `src/search-mapping.js` does the normalization.
+- Output schemas and the README examples updated to the search response shape.
+
 ## [2.0.0] - 2026-06-03
 
 Full 1:1 contract parity with the hosted DexPaprika MCP worker (`mcp.dexpaprika.com`) v2.0.0. Only the transport differs (stdio vs HTTP); tools, parameters, aliases, synonym resolution, sort normalization, output schemas, server instructions and version now match the worker.

--- a/README.md
+++ b/README.md
@@ -163,10 +163,10 @@ const jupiterPools = await getTokenPools({
   limit: 5
 });
 
-// Get top pools on Ethereum:
+// Get top pools on Ethereum (returns `results` with cursor pagination):
 const ethereumPools = await getNetworkPools({
   network: "ethereum",
-  order_by: "volume_usd",
+  order_by: "volume_usd_24h",
   limit: 10
 });
 
@@ -175,7 +175,7 @@ const filteredPools = await getNetworkPoolsFilter({
   network: "ethereum",
   volume_24h_min: 100000,
   created_after: 1710806400,
-  sort_by: "volume_24h",
+  sort_by: "volume_usd_24h",
   limit: 20
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexpaprika-mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A Model Context Protocol server for DexPaprika cryptocurrency data with network-specific pool queries",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,13 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
+import { buildPoolSearchParams, buildTokenSearchParams, toQueryString } from './search-mapping.js';
+
+// Sort-field values accepted by the pool/token tools. Canonical *_24h names are
+// what /pools/search and /tokens/search use; the trailing short names are legacy
+// aliases kept for back-compat and normalized in search-mapping.js.
+const POOL_SORT_FIELDS = ['volume_usd_24h', 'volume_usd_7d', 'volume_usd_30d', 'liquidity_usd', 'txns_24h', 'created_at', 'price_usd', 'price_change_percentage_24h', 'volume_usd', 'transactions', 'last_price_change_usd_24h', 'volume_24h', 'volume_7d', 'volume_30d', 'liquidity'];
+const TOKEN_SORT_FIELDS = ['volume_usd_24h', 'volume_usd_7d', 'volume_usd_30d', 'liquidity_usd', 'txns_24h', 'fdv_usd', 'created_at', 'price_change_percentage_24h', 'volume_24h', 'volume_7d', 'volume_30d', 'txns', 'price_change', 'fdv', 'price_usd'];
 
 // ─────────────────────────────────────────────────────────────────────────────
 // DexPaprika MCP — self-host (stdio) build, contract-aligned 1:1 with the hosted
@@ -425,10 +432,12 @@ const OUTPUT_SCHEMAS = {
   // NOTE: the array/page_info keys below are marked .optional() so SDK 1.29's
   // strict structuredContent validation accepts real upstream shapes. The outer
   // schema is .passthrough(), so the documented key (e.g. `results`) is advertised
-  // while alternate upstream keys still validate. filterNetworkTokens is the key
-  // case: the live API returns `{ data, page_info, query }`, not `{ results }`,
-  // so a required `results` would reject every response. Same defensive reasoning
-  // for the rest — upstream key presence varies and must not hard-fail the client.
+  // while alternate upstream keys still validate. getNetworkPools,
+  // getNetworkPoolsFilter, getTopTokens, and filterNetworkTokens proxy the
+  // /pools/search and /tokens/search endpoints: they return rows under `results`
+  // with cursor pagination (has_next_page + next_cursor), not pools/tokens/data
+  // + page_info. Keeping every key optional keeps the client robust to upstream
+  // shape drift.
   search: {
     tokens: z.array(TokenSummary).optional(),
     pools: z.array(PoolSummary).optional(),
@@ -436,12 +445,12 @@ const OUTPUT_SCHEMAS = {
   },
 
   getNetworkDexes: { dexes: z.array(DexSummary).optional(), page_info: PageInfo.optional() },
-  getNetworkPools: { pools: z.array(PoolSummary).optional(), page_info: PageInfo.optional() },
   getDexPools: { pools: z.array(PoolSummary).optional(), page_info: PageInfo.optional() },
-  getNetworkPoolsFilter: { results: z.array(PoolSummary).optional(), page_info: PageInfo.optional() },
   getTokenPools: { pools: z.array(PoolSummary).optional(), page_info: PageInfo.optional() },
-  getTopTokens: { tokens: z.array(TokenSummary).optional(), page_info: PageInfo.optional() },
-  filterNetworkTokens: { results: z.array(TokenSummary).optional(), page_info: PageInfo.optional() },
+  getNetworkPools: { results: z.array(PoolSummary).optional(), has_next_page: z.boolean().optional(), next_cursor: z.string().nullable().optional(), query: z.record(z.string(), z.unknown()).optional() },
+  getNetworkPoolsFilter: { results: z.array(PoolSummary).optional(), has_next_page: z.boolean().optional(), next_cursor: z.string().nullable().optional(), query: z.record(z.string(), z.unknown()).optional() },
+  getTopTokens: { results: z.array(TokenSummary).optional(), has_next_page: z.boolean().optional(), next_cursor: z.string().nullable().optional(), query: z.record(z.string(), z.unknown()).optional() },
+  filterNetworkTokens: { results: z.array(TokenSummary).optional(), has_next_page: z.boolean().optional(), next_cursor: z.string().nullable().optional(), query: z.record(z.string(), z.unknown()).optional() },
 
   getPoolDetails: {
     id: z.string().optional(),
@@ -650,24 +659,20 @@ registerReadTool(
 // ─── getNetworkPools ─────────────────────────────────────────────────────────
 registerReadTool(
   'getNetworkPools',
-  'PRIMARY POOL FUNCTION: get top liquidity pools on a network. REQUIRED: network. OPTIONAL: page, limit, sort_dir/sort, sort_by/order_by.',
+  'PRIMARY POOL FUNCTION: get top liquidity pools on a network. Proxies /networks/{network}/pools/search: rows are returned under `results` with cursor pagination (has_next_page + next_cursor). REQUIRED: network. OPTIONAL: limit, cursor, sort_dir/sort, sort_by/order_by.',
   {
     network: z.string().describe("REQUIRED: Network ID from getNetworks (e.g., 'ethereum', 'solana')"),
-    page: z.number().optional().default(1).describe('OPTIONAL: Page number for pagination (default: 1, 1-indexed)'),
     limit: z.number().optional().default(10).describe('OPTIONAL: Number of items per page (default: 10, max: 100)'),
+    cursor: z.string().optional().describe('OPTIONAL: Pagination cursor. Pass `next_cursor` from a previous response to fetch the next page. Replaces the old page number.'),
     sort_dir: z.enum(['asc', 'desc']).optional().describe("OPTIONAL (preferred): Sort direction (default: 'desc')"),
     sort: z.enum(['asc', 'desc']).optional().describe('OPTIONAL (deprecated alias of sort_dir): Sort direction'),
-    sort_by: z.enum(['volume_usd', 'price_usd', 'transactions', 'last_price_change_usd_24h', 'created_at']).optional().describe("OPTIONAL (preferred): Field to sort by (default: 'volume_usd')"),
-    order_by: z.enum(['volume_usd', 'price_usd', 'transactions', 'last_price_change_usd_24h', 'created_at']).optional().describe('OPTIONAL (deprecated alias of sort_by): Field to sort by'),
+    sort_by: z.enum(POOL_SORT_FIELDS).optional().describe("OPTIONAL (preferred): Field to sort by (default: 'volume_usd_24h'). Prefer the canonical *_24h names; short legacy names are still accepted."),
+    order_by: z.enum(POOL_SORT_FIELDS).optional().describe('OPTIONAL (deprecated alias of sort_by): Field to sort by'),
   },
   async (args) => {
     try {
       const { network } = args;
-      const page = coercePage(args.page);
-      const limit = args.limit ?? 10;
-      const direction = args.sort_dir ?? args.sort ?? 'desc';
-      const field = args.sort_by ?? args.order_by ?? 'volume_usd';
-      const endpoint = `/networks/${network}/pools?page=${page}&limit=${limit}&sort=${direction}&order_by=${field}`;
+      const endpoint = `/networks/${network}/pools/search${toQueryString(buildPoolSearchParams(args))}`;
       return jsonText(await fetchFromAPI(endpoint));
     } catch (error) {
       return errorText(error);
@@ -707,11 +712,11 @@ registerReadTool(
 // ─── getNetworkPoolsFilter ───────────────────────────────────────────────────
 registerReadTool(
   'getNetworkPoolsFilter',
-  'Filter pools by volume, liquidity, transactions, and creation time. REQUIRED: network. OPTIONAL: page, limit, volume_24h_min/max, volume_7d_min/max, liquidity_usd_min/max, txns_24h_min, created_after, created_before, sort_by/order_by, sort_dir/sort.',
+  'Filter pools by volume, liquidity, transactions, and creation time. Proxies /networks/{network}/pools/search with filter params; rows are returned under `results` with cursor pagination. REQUIRED: network. OPTIONAL: limit, cursor, volume_24h_min/max, volume_7d_min/max, liquidity_usd_min/max, txns_24h_min, created_after, created_before, sort_by/order_by, sort_dir/sort.',
   {
     network: z.string().describe("REQUIRED: Network ID from getNetworks (e.g., 'ethereum', 'solana')"),
-    page: z.number().optional().default(1).describe('OPTIONAL: Page number for pagination (default: 1, 1-indexed)'),
     limit: z.number().optional().default(50).describe('OPTIONAL: Number of items per page (default: 50, max: 100)'),
+    cursor: z.string().optional().describe('OPTIONAL: Pagination cursor. Pass `next_cursor` from a previous response to fetch the next page. Replaces the old page number.'),
     volume_24h_min: z.number().optional().describe('OPTIONAL: Minimum 24h volume in USD'),
     volume_24h_max: z.number().optional().describe('OPTIONAL: Maximum 24h volume in USD'),
     volume_7d_min: z.number().optional().describe('OPTIONAL: Minimum 7d volume in USD'),
@@ -721,22 +726,15 @@ registerReadTool(
     txns_24h_min: z.number().optional().describe('OPTIONAL: Minimum number of transactions in 24h'),
     created_after: z.number().optional().describe('OPTIONAL: Only pools created after this UNIX timestamp'),
     created_before: z.number().optional().describe('OPTIONAL: Only pools created before this UNIX timestamp'),
-    sort_by: z.enum(['volume_24h', 'volume_7d', 'volume_30d', 'liquidity', 'txns_24h', 'created_at']).optional().describe("OPTIONAL (preferred): Field to sort by (default: 'volume_24h')"),
-    order_by: z.enum(['volume_24h', 'volume_7d', 'volume_30d', 'liquidity', 'txns_24h', 'created_at']).optional().describe('OPTIONAL (deprecated alias of sort_by): Field to sort by'),
+    sort_by: z.enum(POOL_SORT_FIELDS).optional().describe("OPTIONAL (preferred): Field to sort by (default: 'volume_usd_24h'). Prefer the canonical *_24h names; short legacy names are still accepted."),
+    order_by: z.enum(POOL_SORT_FIELDS).optional().describe('OPTIONAL (deprecated alias of sort_by): Field to sort by'),
     sort_dir: z.enum(['asc', 'desc']).optional().describe("OPTIONAL (preferred): Sort direction (default: 'desc')"),
     sort: z.enum(['asc', 'desc']).optional().describe('OPTIONAL (deprecated alias of sort_dir): Sort direction'),
   },
   async (args) => {
     try {
       const { network } = args;
-      const page = coercePage(args.page);
-      const limit = args.limit ?? 50;
-      const sort_by = args.sort_by ?? args.order_by ?? 'volume_24h';
-      const sort_dir = args.sort_dir ?? args.sort ?? 'desc';
-      let endpoint = `/networks/${network}/pools/filter?page=${page}&limit=${limit}&sort_by=${sort_by}&sort_dir=${sort_dir}`;
-      for (const k of ['volume_24h_min', 'volume_24h_max', 'volume_7d_min', 'volume_7d_max', 'liquidity_usd_min', 'liquidity_usd_max', 'txns_24h_min', 'created_after', 'created_before']) {
-        if (args[k] !== undefined) endpoint += `&${k}=${args[k]}`;
-      }
+      const endpoint = `/networks/${network}/pools/search${toQueryString(buildPoolSearchParams(args))}`;
       return jsonText(await fetchFromAPI(endpoint));
     } catch (error) {
       return errorText(error);
@@ -910,35 +908,29 @@ registerReadTool(
 // ─── filterNetworkTokens ─────────────────────────────────────────────────────
 registerReadTool(
   'filterNetworkTokens',
-  'Filter tokens by volume, liquidity, FDV, transactions, and creation time. REQUIRED: network. OPTIONAL: page, limit, volume_24h_min/max, liquidity_usd_min, fdv_min/max, txns_24h_min, created_after/before, sort_by/order_by, sort_dir/sort.',
+  'Filter tokens by volume, liquidity, FDV, transactions, and creation time. Proxies /networks/{network}/tokens/search with filter params; rows are returned under `results` with cursor pagination. REQUIRED: network. OPTIONAL: limit, cursor, volume_24h_min/max, liquidity_usd_min/max, fdv_min/max, txns_24h_min, created_after/before, sort_by/order_by, sort_dir/sort.',
   {
     network: z.string().describe("REQUIRED: Network ID from getNetworks (e.g., 'ethereum', 'solana')"),
-    page: z.number().optional().default(1).describe('OPTIONAL: Page number for pagination (default: 1, 1-indexed)'),
     limit: z.number().optional().default(50).describe('OPTIONAL: Number of items per page (default: 50, max: 100)'),
+    cursor: z.string().optional().describe('OPTIONAL: Pagination cursor. Pass `next_cursor` from a previous response to fetch the next page. Replaces the old page number.'),
     volume_24h_min: z.number().optional().describe('OPTIONAL: Minimum 24h volume in USD'),
     volume_24h_max: z.number().optional().describe('OPTIONAL: Maximum 24h volume in USD'),
     liquidity_usd_min: z.number().optional().describe('OPTIONAL: Minimum token liquidity in USD'),
+    liquidity_usd_max: z.number().optional().describe('OPTIONAL: Maximum token liquidity in USD'),
     fdv_min: z.number().optional().describe('OPTIONAL: Minimum fully diluted valuation in USD'),
     fdv_max: z.number().optional().describe('OPTIONAL: Maximum fully diluted valuation in USD'),
     txns_24h_min: z.number().optional().describe('OPTIONAL: Minimum number of transactions in 24h'),
     created_after: z.number().optional().describe('OPTIONAL: Only tokens created after this UNIX timestamp'),
     created_before: z.number().optional().describe('OPTIONAL: Only tokens created before this UNIX timestamp'),
-    sort_by: z.enum(['volume_24h', 'volume_7d', 'volume_30d', 'liquidity_usd', 'txns_24h', 'created_at', 'fdv']).optional().describe("OPTIONAL (preferred): Field to sort by (default: 'volume_24h')"),
-    order_by: z.enum(['volume_24h', 'volume_7d', 'volume_30d', 'liquidity_usd', 'txns_24h', 'created_at', 'fdv']).optional().describe('OPTIONAL (deprecated alias of sort_by): Field to sort by'),
+    sort_by: z.enum(TOKEN_SORT_FIELDS).optional().describe("OPTIONAL (preferred): Field to sort by (default: 'volume_usd_24h'). Prefer the canonical names; short legacy names are still accepted."),
+    order_by: z.enum(TOKEN_SORT_FIELDS).optional().describe('OPTIONAL (deprecated alias of sort_by): Field to sort by'),
     sort_dir: z.enum(['asc', 'desc']).optional().describe("OPTIONAL (preferred): Sort direction (default: 'desc')"),
     sort: z.enum(['asc', 'desc']).optional().describe('OPTIONAL (deprecated alias of sort_dir): Sort direction'),
   },
   async (args) => {
     try {
       const { network } = args;
-      const page = coercePage(args.page);
-      const limit = args.limit ?? 50;
-      const sort_by = args.sort_by ?? args.order_by ?? 'volume_24h';
-      const sort_dir = args.sort_dir ?? args.sort ?? 'desc';
-      let endpoint = `/networks/${network}/tokens/filter?page=${page}&limit=${limit}&sort_by=${sort_by}&sort_dir=${sort_dir}`;
-      for (const k of ['volume_24h_min', 'volume_24h_max', 'liquidity_usd_min', 'fdv_min', 'fdv_max', 'txns_24h_min', 'created_after', 'created_before']) {
-        if (args[k] !== undefined) endpoint += `&${k}=${args[k]}`;
-      }
+      const endpoint = `/networks/${network}/tokens/search${toQueryString(buildTokenSearchParams(args))}`;
       return jsonText(await fetchFromAPI(endpoint));
     } catch (error) {
       return errorText(error);
@@ -949,24 +941,20 @@ registerReadTool(
 // ─── getTopTokens ────────────────────────────────────────────────────────────
 registerReadTool(
   'getTopTokens',
-  'Get top tokens on a network ranked by volume, price, liquidity, or activity. Each token includes enriched metadata and multi-timeframe metrics (24h, 1h, 5m). REQUIRED: network. OPTIONAL: page, limit, sort_by/order_by, sort_dir/sort.',
+  'Get top tokens on a network ranked by volume, liquidity, transactions, FDV, or 24h price change. Proxies /networks/{network}/tokens/search: rows are returned under `results` (address, price_usd, volume_usd_24h, liquidity_usd, fdv_usd, txns_24h, price_change_percentage_24h) with cursor pagination. Ordering by price is not supported and falls back to volume. REQUIRED: network. OPTIONAL: limit, cursor, sort_by/order_by, sort_dir/sort.',
   {
     network: z.string().describe("REQUIRED: Network ID from getNetworks (e.g., 'ethereum', 'solana')"),
-    page: z.number().optional().default(1).describe('OPTIONAL: Page number for pagination (default: 1, 1-indexed)'),
     limit: z.number().optional().default(50).describe('OPTIONAL: Number of items per page (default: 50, max: 100)'),
-    sort_by: z.enum(['volume_24h', 'price_usd', 'liquidity_usd', 'txns', 'price_change']).optional().describe("OPTIONAL (preferred): Field to sort by (default: 'volume_24h')"),
-    order_by: z.enum(['volume_24h', 'price_usd', 'liquidity_usd', 'txns', 'price_change']).optional().describe('OPTIONAL (deprecated alias of sort_by): Field to sort by'),
+    cursor: z.string().optional().describe('OPTIONAL: Pagination cursor. Pass `next_cursor` from a previous response to fetch the next page. Replaces the old page number.'),
+    sort_by: z.enum(TOKEN_SORT_FIELDS).optional().describe("OPTIONAL (preferred): Field to sort by (default: 'volume_usd_24h'). Prefer the canonical names; short legacy names are still accepted."),
+    order_by: z.enum(TOKEN_SORT_FIELDS).optional().describe('OPTIONAL (deprecated alias of sort_by): Field to sort by'),
     sort_dir: z.enum(['asc', 'desc']).optional().describe("OPTIONAL (preferred): Sort direction (default: 'desc')"),
     sort: z.enum(['asc', 'desc']).optional().describe('OPTIONAL (deprecated alias of sort_dir): Sort direction'),
   },
   async (args) => {
     try {
       const { network } = args;
-      const page = coercePage(args.page);
-      const limit = args.limit ?? 50;
-      const direction = args.sort_dir ?? args.sort ?? 'desc';
-      const field = args.sort_by ?? args.order_by ?? 'volume_24h';
-      const endpoint = `/networks/${network}/tokens/top?page=${page}&limit=${limit}&order_by=${field}&sort=${direction}`;
+      const endpoint = `/networks/${network}/tokens/search${toQueryString(buildTokenSearchParams(args))}`;
       return jsonText(await fetchFromAPI(endpoint));
     } catch (error) {
       return errorText(error);

--- a/src/search-mapping.js
+++ b/src/search-mapping.js
@@ -1,0 +1,135 @@
+/**
+ * Search-endpoint parameter mapping.
+ *
+ * The legacy DexPaprika REST endpoints /networks/{network}/pools,
+ * /networks/{network}/pools/filter, /networks/{network}/tokens/top, and
+ * /networks/{network}/tokens/filter were removed (HTTP 410). They are replaced
+ * by the unified search endpoints:
+ *   - GET /networks/{network}/pools/search
+ *   - GET /networks/{network}/tokens/search
+ *
+ * The search endpoints use canonical field names (volume_usd_24h, txns_24h,
+ * price_change_percentage_24h, ...) and reject the old short names with HTTP
+ * 400. The MCP tools keep their old names and sort-field values for client
+ * back-compat, so every value an agent supplies is normalized to the canonical
+ * form before the upstream call.
+ *
+ * Verified live against api.dexpaprika.com (2026-06-30): every canonical value
+ * below returns 200 and sorts correctly; the legacy values 400. tokens/search
+ * does not support price_usd ordering (400), so it falls back to volume.
+ */
+
+const POOL_SORT_CANONICAL = new Set([
+  'volume_usd_24h', 'volume_usd_7d', 'volume_usd_30d', 'liquidity_usd',
+  'txns_24h', 'created_at', 'price_usd', 'price_change_percentage_24h',
+]);
+
+const POOL_SORT_LEGACY = {
+  volume_usd: 'volume_usd_24h',
+  transactions: 'txns_24h',
+  last_price_change_usd_24h: 'price_change_percentage_24h',
+  volume_24h: 'volume_usd_24h',
+  volume_7d: 'volume_usd_7d',
+  volume_30d: 'volume_usd_30d',
+  liquidity: 'liquidity_usd',
+};
+
+const TOKEN_SORT_CANONICAL = new Set([
+  'volume_usd_24h', 'volume_usd_7d', 'volume_usd_30d', 'liquidity_usd',
+  'txns_24h', 'fdv_usd', 'created_at', 'price_change_percentage_24h',
+]);
+
+const TOKEN_SORT_LEGACY = {
+  volume_24h: 'volume_usd_24h',
+  volume_7d: 'volume_usd_7d',
+  volume_30d: 'volume_usd_30d',
+  txns: 'txns_24h',
+  price_change: 'price_change_percentage_24h',
+  fdv: 'fdv_usd',
+  // tokens/search rejects price_usd ordering (HTTP 400) -- fall back to volume.
+  price_usd: 'volume_usd_24h',
+};
+
+export function mapPoolSortField(value) {
+  if (typeof value !== 'string' || value === '') return 'volume_usd_24h';
+  if (POOL_SORT_CANONICAL.has(value)) return value;
+  return POOL_SORT_LEGACY[value] || 'volume_usd_24h';
+}
+
+export function mapTokenSortField(value) {
+  if (typeof value !== 'string' || value === '') return 'volume_usd_24h';
+  if (TOKEN_SORT_CANONICAL.has(value)) return value;
+  return TOKEN_SORT_LEGACY[value] || 'volume_usd_24h';
+}
+
+// Legacy filter param name -> canonical /search filter param name.
+const POOL_FILTER_PARAM = {
+  volume_24h_min: 'volume_usd_24h_min',
+  volume_24h_max: 'volume_usd_24h_max',
+  volume_7d_min: 'volume_usd_7d_min',
+  volume_7d_max: 'volume_usd_7d_max',
+  liquidity_usd_min: 'liquidity_usd_min',
+  liquidity_usd_max: 'liquidity_usd_max',
+  txns_24h_min: 'txns_24h_min',
+  created_after: 'created_after',
+  created_before: 'created_before',
+};
+
+const TOKEN_FILTER_PARAM = {
+  volume_24h_min: 'volume_usd_24h_min',
+  volume_24h_max: 'volume_usd_24h_max',
+  liquidity_usd_min: 'liquidity_usd_min',
+  liquidity_usd_max: 'liquidity_usd_max',
+  fdv_min: 'fdv_min',
+  fdv_max: 'fdv_max',
+  txns_24h_min: 'txns_24h_min',
+  created_after: 'created_after',
+  created_before: 'created_before',
+};
+
+function normalizeDirection(args) {
+  const dir = args.sort_dir ?? args.sort;
+  return dir === 'asc' ? 'asc' : 'desc';
+}
+
+/** Build query params for /networks/{network}/pools/search from tool args. */
+export function buildPoolSearchParams(args) {
+  const params = {
+    order_by: mapPoolSortField(args.sort_by ?? args.order_by),
+    sort: normalizeDirection(args),
+  };
+  if (args.limit !== undefined && args.limit !== null) params.limit = args.limit;
+  if (typeof args.cursor === 'string' && args.cursor !== '') params.cursor = args.cursor;
+  for (const [legacy, canonical] of Object.entries(POOL_FILTER_PARAM)) {
+    const v = args[legacy];
+    if (v !== undefined && v !== null) params[canonical] = v;
+  }
+  return params;
+}
+
+/** Build query params for /networks/{network}/tokens/search from tool args. */
+export function buildTokenSearchParams(args) {
+  const params = {
+    order_by: mapTokenSortField(args.sort_by ?? args.order_by),
+    sort: normalizeDirection(args),
+  };
+  if (args.limit !== undefined && args.limit !== null) params.limit = args.limit;
+  if (typeof args.cursor === 'string' && args.cursor !== '') params.cursor = args.cursor;
+  if (typeof args.query === 'string' && args.query !== '') params.query = args.query;
+  for (const [legacy, canonical] of Object.entries(TOKEN_FILTER_PARAM)) {
+    const v = args[legacy];
+    if (v !== undefined && v !== null) params[canonical] = v;
+  }
+  return params;
+}
+
+/** Serialize a params object to a `?a=b&c=d` query string (empty -> ""). */
+export function toQueryString(params) {
+  const sp = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v === undefined || v === null || v === '') continue;
+    sp.set(k, String(v));
+  }
+  const s = sp.toString();
+  return s ? `?${s}` : '';
+}

--- a/src/test_methods.js
+++ b/src/test_methods.js
@@ -41,22 +41,25 @@ async function testEndpoint(name, endpoint) {
 }
 
 async function runTests() {
-  console.log('Starting DexPaprika API endpoint tests (v1.1.0)...');
-  console.log('Note: The global /pools endpoint has been removed as of v1.1.0');
-  
+  console.log('Starting DexPaprika API endpoint tests...');
+  console.log('Note: the pool/token list and filter endpoints were removed; pool and token discovery now uses /pools/search and /tokens/search.');
+
   // Test each endpoint
   await testEndpoint('getNetworks', '/networks');
   await testEndpoint('getNetworkDexes', '/networks/ethereum/dexes');
-  await testEndpoint('getNetworkPools (Ethereum)', '/networks/ethereum/pools');
-  await testEndpoint('getNetworkPools (Solana)', '/networks/solana/pools');
+  await testEndpoint('getNetworkPools (Ethereum)', '/networks/ethereum/pools/search?order_by=volume_usd_24h&limit=5');
+  await testEndpoint('getNetworkPools (Solana)', '/networks/solana/pools/search?order_by=volume_usd_24h&limit=5');
+  await testEndpoint('getNetworkPoolsFilter', '/networks/ethereum/pools/search?liquidity_usd_min=1000000&order_by=volume_usd_24h&limit=5');
   await testEndpoint('getDexPools', '/networks/ethereum/dexes/uniswap_v3/pools');
   await testEndpoint('getPoolDetails', '/networks/ethereum/pools/0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640');
   await testEndpoint('getTokenDetails', '/networks/ethereum/tokens/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48');
+  await testEndpoint('getTopTokens', '/networks/ethereum/tokens/search?order_by=volume_usd_24h&limit=5');
+  await testEndpoint('filterNetworkTokens', '/networks/ethereum/tokens/search?volume_usd_24h_min=10000000&order_by=volume_usd_24h&limit=5');
   await testEndpoint('getTokenMultiPrices', '/networks/ethereum/multi/prices?tokens=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&tokens=0xdac17f958d2ee523a2206206994597c13d831ec7');
   await testEndpoint('search', '/search?query=ethereum');
   await testEndpoint('getStats', '/stats');
-  
-  console.log('\nAll tests completed! All endpoints are using the network-specific approach.');
+
+  console.log('\nAll tests completed!');
 }
 
 runTests().catch(error => {


### PR DESCRIPTION
The npm `dexpaprika-mcp` equivalent of the hosted-MCP fix.

## Problem

DexPaprika removed four REST endpoints (HTTP 410): `/networks/{network}/pools`, `/networks/{network}/pools/filter`, `/networks/{network}/tokens/top`, `/networks/{network}/tokens/filter`. So `getNetworkPools`, `getNetworkPoolsFilter`, `getTopTokens`, and `filterNetworkTokens` were erroring.

## Fix

Repoint all four to the unified search endpoints (tool names unchanged for client back-compat):

- `getNetworkPools`, `getNetworkPoolsFilter` -> `/networks/{network}/pools/search`
- `getTopTokens`, `filterNetworkTokens` -> `/networks/{network}/tokens/search`

New `src/search-mapping.js` normalizes legacy sort-field values (`volume_usd` -> `volume_usd_24h`, `transactions` -> `txns_24h`, `last_price_change_usd_24h` -> `price_change_percentage_24h`, ...) and filter param names (`volume_24h_min` -> `volume_usd_24h_min`, ...). The search endpoints `400` on the old short names, so this mapping is required; it keeps existing callers working.

Responses now return rows under `results` with cursor pagination (`has_next_page` + `next_cursor`). Updated to match: output schemas, README examples, the `test:api` smoke test, and CHANGELOG.

## Behaviour change

`results` (was `pools`/`tokens`) + cursor pagination (was page numbers); rows use canonical field names (`volume_usd_24h`, `txns_24h`, `liquidity_usd`, `fdv_usd`, `price_change_percentage_24h`). `getTopTokens` can no longer order by price (the search endpoint rejects it; falls back to volume). Mirrors the upstream API change.

## Verified

- `npm run test:api` (live): all 14 endpoint cases SUCCESS, including the 4 migrated tools
- End-to-end over stdio: `getNetworkPools`, `filterNetworkTokens` (legacy `volume_24h_min` mapped), `getTopTokens` (legacy `price_usd` -> volume) all return `results[]`
- Also caught + fixed a stale dev dep: `node_modules` had SDK 1.6.1 while `package.json` requires ^1.29.0, which made the server fail to start (`registerTool is not a function`); `npm install` resolves it

## Publish notes

- Version bumped `2.0.0` -> `2.1.0`. npm `latest` is `1.5.0`; `2.0.0` was prepared in source but never published, so this will be the first 2.x release on npm.
- `SERVER_VERSION` stays `2.0.0` (tracks the hosted worker's MCP contract).
- Publish flow (unchanged): `npm install && npm run build && npm publish` (dist/ is gitignored and built at publish time).