### PR TITLE
Surface 410 replacement hint in errors (v2.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the DexPaprika MCP Server will be documented in this file.
 
+## [2.1.1] - 2026-07-01
+
+### Added
+- **Deprecation-aware errors**: when the API returns an error whose body carries a `replacement` field, the error now includes the API's message plus `Use <replacement> instead.` and a `metadata.replacement`, so agents are pointed at the new endpoint instead of a bare status line. Generic across any error status, not hardcoded to specific endpoints.
+
 ## [2.1.0] - 2026-06-30
 
 Migrate the pool and token list/filter tools to the unified search endpoints. DexPaprika removed `/networks/{network}/pools`, `/networks/{network}/pools/filter`, `/networks/{network}/tokens/top`, and `/networks/{network}/tokens/filter` (HTTP 410), so `getNetworkPools`, `getNetworkPoolsFilter`, `getTopTokens`, and `filterNetworkTokens` were erroring until this release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dexpaprika-mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dexpaprika-mcp",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexpaprika-mcp",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A Model Context Protocol server for DexPaprika cryptocurrency data with network-specific pool queries",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,46 @@ function buildErrorResponse(code, message, retryable, suggestion, correctedExamp
   return error;
 }
 
-function parseAPIError(status, statusText, endpoint) {
+// Defensively parse a deprecation hint out of an error response body. The API
+// signals a removed/moved endpoint with a JSON body of the shape
+// { "code": 410, "message": "endpoint removed", "replacement": "/networks/:network/pools/search" }.
+// We key on the presence of a string "replacement" field so ANY future
+// deprecation self-documents (not just 410, not hardcoded to any endpoint).
+// Returns null when the body is missing, not JSON, or has no usable replacement,
+// so callers fall back to the existing status-based error behavior.
+function parseDeprecationHint(body) {
+  if (!body || typeof body !== 'string') return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const replacement = parsed.replacement;
+  if (typeof replacement !== 'string' || replacement.length === 0) return null;
+  const apiMessage = typeof parsed.message === 'string' ? parsed.message : null;
+  return { replacement, apiMessage };
+}
+
+function parseAPIError(status, statusText, endpoint, body) {
+  // Generic, self-documenting deprecation handling: if the error body carries a
+  // "replacement" hint, surface BOTH the API message and the replacement path,
+  // for ANY error status. Keeps the DP<status>_ERROR code structure.
+  const hint = parseDeprecationHint(body);
+  if (hint) {
+    const baseMessage = (hint.apiMessage ?? `API request failed: ${status} ${statusText}`)
+      .replace(/\s*\.?\s*$/, '');
+    return buildErrorResponse(
+      `DP${status}_ERROR`,
+      `${baseMessage}. Use ${hint.replacement} instead.`,
+      false,
+      `This endpoint has been deprecated or removed. Use ${hint.replacement} instead.`,
+      undefined,
+      { endpoint, status, replacement: hint.replacement },
+    );
+  }
+
   if (status === 404 && endpoint.includes('/networks/')) {
     const networkMatch = endpoint.match(/\/networks\/([^/?]+)/);
     const providedNetwork = networkMatch ? networkMatch[1] : 'unknown';
@@ -204,9 +243,18 @@ async function fetchFromAPI(endpoint) {
   const url = `${API_BASE_URL}${endpoint}`;
   const response = await fetch(url);
   if (!response.ok) {
+    // Read the error body so a deprecation hint (a "replacement" field) can be
+    // surfaced to the caller. Defensive: the body may be empty or non-JSON, in
+    // which case parseAPIError falls back to status-based behavior.
+    let body = '';
+    try {
+      body = await response.text();
+    } catch {
+      body = '';
+    }
     console.error(`[upstream] url=${url} http_status=${response.status} text="${response.statusText}"`);
     // Preserve the package's structured error contract.
-    throw parseAPIError(response.status, response.statusText, endpoint);
+    throw parseAPIError(response.status, response.statusText, endpoint, body);
   }
   return response.json();
 }


### PR DESCRIPTION
On an error whose body carries a `replacement` field, `parseAPIError` now includes the API message + `Use <replacement> instead.` and `metadata.replacement`, so agents self-heal to the new endpoint. Generic across any error status; defensive fallback when absent. Version 2.1.0 -> 2.1.1. `node --check` + live `test:api` (13/13) pass. Publish after merge: `npm publish`.