### PR TITLE
Pin npx snippets to dexpaprika-mcp@latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install -g dexpaprika-mcp
 dexpaprika-mcp
 
 # Or run directly without installation
-npx dexpaprika-mcp
+npx dexpaprika-mcp@latest
 ```
 
 DexPaprika MCP connects Claude to live DEX data across multiple blockchains. No API keys required. [Installation](#installation) | [Configuration](#claude-desktop-integration) | [API Reference](https://docs.dexpaprika.com/introduction)
@@ -76,7 +76,7 @@ Add the following to your Claude Desktop configuration file:
   "mcpServers": {
     "dexpaprika": {
       "command": "npx",
-      "args": ["dexpaprika-mcp"]
+      "args": ["dexpaprika-mcp@latest"]
     }
   }
 }


### PR DESCRIPTION
## Why

Unversioned `npx dexpaprika-mcp` does not check the registry once npx has a cached copy. It keeps running whatever version was installed first. I hit this on a real machine: the npx cache was still serving 1.0.3 from March 2025 while the latest release is 2.1.1, so every README snippet quietly ran a year-old server.

Pinning `@latest` forces npx to resolve against the registry on each run, so users always get the current release.

## What changed

- README TL;DR: `npx dexpaprika-mcp` is now `npx dexpaprika-mcp@latest`
- README Claude Desktop config: `"args": ["dexpaprika-mcp"]` is now `"args": ["dexpaprika-mcp@latest"]`

Left untouched on purpose:

- `smithery.yaml` runs `node dist/bin.js` from the built package, not npx, so there is nothing to pin
- `glama.json` only lists maintainers
- The Smithery install line uses `@smithery/cli` with a Smithery registry id, not our npm package
- Global install instructions (`npm install -g`) already have an explicit update path

## Verified

- Ran `npx -y dexpaprika-mcp@latest --version` on a machine whose unversioned npx cache held 1.0.3. It resolved and installed 2.1.1 from the registry (confirmed via the package.json in the new npx cache entry) and the server started.
- `npm view dexpaprika-mcp version` returns 2.1.1.

One side note: the startup banner prints "v2.0.0" because the string in `src/index.js` is hardcoded. Not touched here since this PR only changes install snippets, but it is worth a follow-up.
