### PR TITLE
Report the real package version in the startup banner

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,10 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
+import { createRequire } from 'module';
 import { buildPoolSearchParams, buildTokenSearchParams, toQueryString } from './search-mapping.js';
+
+const PACKAGE_VERSION = createRequire(import.meta.url)('../package.json').version;
 
 // Sort-field values accepted by the pool/token tools. Canonical *_24h names are
 // what /pools/search and /tokens/search use; the trailing short names are legacy
@@ -567,7 +570,7 @@ function buildCapabilitiesDocument() {
   return {
     name: SERVER_CANONICAL_NAME,
     aliases: SERVER_ALIASES,
-    server: { name: 'DexPaprika MCP', version: '2.0.0' },
+    server: { name: 'DexPaprika MCP', version: SERVER_VERSION },
     tools_count: 17,
     stats: {
       networks: 35,
@@ -1096,7 +1099,7 @@ async function main() {
   try {
     const transport = new StdioServerTransport();
     await server.connect(transport);
-    console.error('DexPaprika MCP server (v2.0.0) is running...');
+    console.error(`DexPaprika MCP server v${PACKAGE_VERSION} (tool contract v${SERVER_VERSION}) is running...`);
   } catch (error) {
     console.error('Failed to start server:', error);
     process.exit(1);


### PR DESCRIPTION
The startup banner hardcoded v2.0.0, so a 2.1.1 install prints a banner claiming 2.0.0. Confusing when checking whether the /search migration (2.1.0+) is actually the version running.

Changes:
- Banner now reads the version from package.json: DexPaprika MCP server v2.1.1 (tool contract v2.0.0) is running...
- The tool-contract version stays visible since it tracks parity with the hosted worker, but it is now labeled as such.
- getCapabilities server block reuses SERVER_VERSION instead of a second hardcoded 2.0.0 string. No behavior change.

Tested: node --check passes, ran the server over stdio and confirmed the new banner output.