### PR TITLE
Refresh getCapabilities stats to live /stats values (36 chains, 33M+ tokens, 36M+ pools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ If you prefer zero setup, point any MCP-compatible client directly at the hosted
 | Tool | Description |
 |------|-------------|
 | `getCapabilities` | Server capabilities, workflow patterns, network synonyms, and best practices. **Start here.** |
-| `getNetworks` | List all 33 supported blockchain networks |
+| `getNetworks` | List every supported blockchain network (36+) |
 | `getStats` | High-level ecosystem stats (total networks, DEXes, pools, tokens) |
 | `search` | Search tokens, pools, and DEXes across ALL networks by name, symbol, or address |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dexpaprika-mcp",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dexpaprika-mcp",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/index.js
+++ b/src/index.js
@@ -573,9 +573,9 @@ function buildCapabilitiesDocument() {
     server: { name: 'DexPaprika MCP', version: SERVER_VERSION },
     tools_count: 17,
     stats: {
-      networks: 35,
-      tokens_approx: 29_000_000,
-      pools_approx: 31_000_000,
+      networks: 36,
+      tokens_approx: 33_000_000,
+      pools_approx: 36_000_000,
       free: true,
       requires_api_key: false,
     },


### PR DESCRIPTION
getCapabilities was reporting coverage numbers from a while back. Live check today:

```
curl -s https://api.dexpaprika.com/stats
{"chains":36,"factories":231,"pools":36306148,"tokens":33574382}
```

Changes:

- `src/index.js` buildCapabilitiesDocument: networks 35 to 36, tokens_approx 29M to 33M, pools_approx 31M to 36M. These bring the self-host build in line with live /stats. The hosted worker gets the identical refresh in a separate PR on its own repo and the two artifacts match again once that one is merged and deployed.
- `README.md` getNetworks row said 33 networks; reworded to "every supported blockchain network (36+)" so it does not go stale the next time a chain lands.
- `package-lock.json` was still on 2.1.0 after the 2.1.1 version bump; npm install synced it.

npm test passes (server smoke test, v2.1.1). No publish here; this rides with the pending 2.1.2 release.
