### PR TITLE
Release 2.1.2: version bump, README tool tables to 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the DexPaprika MCP Server will be documented in this file.
 
+## [2.1.2] - 2026-07-14
+
+### Fixed
+- Startup banner reports the real package version instead of a hardcoded v2.0.0; the hosted tool-contract version is shown separately.
+- `getCapabilities` stats refreshed to live coverage: 36 networks, 33M+ tokens, 36M+ pools.
+- README tool count corrected from 14 to 17; added the missing `getTopTokens`, `filterNetworkTokens`, and `submitFeedback` rows to the tools tables.
+
 ## [2.1.1] - 2026-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npx dexpaprika-mcp@latest
 
 DexPaprika MCP connects Claude to live DEX data across multiple blockchains. No API keys required. [Installation](#installation) | [Configuration](#claude-desktop-integration) | [API Reference](https://docs.dexpaprika.com/introduction)
 
-> **Prefer zero setup?** Use the hosted MCP server at [mcp.dexpaprika.com](https://mcp.dexpaprika.com) — no installation, no API key, same 14 tools. See [Hosted Alternative](#hosted-alternative-no-installation) for transport endpoints.
+> **Prefer zero setup?** Use the hosted MCP server at [mcp.dexpaprika.com](https://mcp.dexpaprika.com): no installation, no API key, same 17 tools. See [Hosted Alternative](#hosted-alternative-no-installation) for transport endpoints.
 
 ## Version 1.3.0 Update Highlights
 
@@ -107,7 +107,7 @@ If you prefer zero setup, point any MCP-compatible client directly at the hosted
 }
 ```
 
-## Available Tools (14)
+## Available Tools (17)
 
 ### Discovery
 
@@ -142,6 +142,14 @@ If you prefer zero setup, point any MCP-compatible client directly at the hosted
 | `getTokenDetails` | Detailed token information | `network`, `token_address` |
 | `getTokenPools` | Liquidity pools containing a token | `network`, `token_address` |
 | `getTokenMultiPrices` | Batched prices for up to 10 tokens | `network`, `tokens[]` |
+| `getTopTokens` | Top tokens on a network ranked by volume, liquidity, FDV, or 24h price change | `network` |
+| `filterNetworkTokens` | Filter tokens by volume, liquidity, FDV, transactions, and creation time | `network` |
+
+### Feedback
+
+| Tool | Description | Required Parameters |
+|------|-------------|---------------------|
+| `submitFeedback` | Report unexpected tool behavior, missing data, or docs gaps straight to the team | `goal` |
 
 ### Example Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dexpaprika-mcp",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dexpaprika-mcp",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexpaprika-mcp",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A Model Context Protocol server for DexPaprika cryptocurrency data with network-specific pool queries",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Prepares the 2.1.2 npm publish.

- package.json and lockfile: 2.1.1 to 2.1.2. Ships the already-merged startup banner fix (#26) and getCapabilities stats refresh (#27).
- README: the hosted-alternative note and the Available Tools heading said 14 tools while the server registers 17. Counted the registrations in src/index.js: the tables were missing getTopTokens, filterNetworkTokens and submitFeedback. Added all three rows (new Feedback section for submitFeedback) and fixed both counts.
- CHANGELOG entry for 2.1.2.

Tested: npm test passes, node --check clean, banner smoke run prints v2.1.2 (tool contract v2.0.0).

After merge: npm publish (needs OTP).