### PR TITLE
Release 2.1.3: repackage broken 2.1.2, add prepack build hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the DexPaprika MCP Server will be documented in this file.
 
+## [2.1.3] - 2026-07-14
+
+### Fixed
+- **Repackage of 2.1.2, which is broken on npm**: the 2.1.2 tarball was published without the dist/ directory, so its bin target (dist/bin.js) does not exist and fresh `npx dexpaprika-mcp` installs fail or silently fall back to an older binary on PATH. 2.1.2 is deprecated on the registry; no source changes besides packaging.
+- Added a `prepack` hook that runs the build automatically, so any future `npm pack`/`npm publish` always includes dist/.
+
 ## [2.1.2] - 2026-07-14
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dexpaprika-mcp",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dexpaprika-mcp",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexpaprika-mcp",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "A Model Context Protocol server for DexPaprika cryptocurrency data with network-specific pool queries",
   "main": "dist/index.js",
   "type": "module",
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "mkdir -p dist && cp -r src/* dist/ && chmod +x dist/bin.js",
+    "prepack": "npm run build",
     "start": "node src/index.js",
     "watch": "nodemon --watch src --exec npm start",
     "test": "node src/test.js",


### PR DESCRIPTION
2.1.2 on npm is broken: the tarball was published without dist/ (16 files vs 2.1.1's 22), so the bin target dist/bin.js does not exist in the package. A fresh npx dexpaprika-mcp install either fails or silently executes an older dexpaprika-mcp found on PATH (reproduced locally: npx -y dexpaprika-mcp@2.1.2 answered the MCP handshake with serverInfo 1.2.0 from a stale global install).

Root cause: the build step that creates dist/ is manual, and the publish ran from a fresh clone that never built. This release:

- bumps to 2.1.3 (no source changes, packaging only)
- adds a prepack hook so npm pack and npm publish always build dist/ first; verified from a clean tree that the tarball now contains all 6 dist files including dist/bin.js
- changelog entry marking 2.1.2 as broken

After merge and publish, 2.1.2 should be deprecated on the registry: npm deprecate dexpaprika-mcp@2.1.2 "Broken package, missing dist/. Use >=2.1.3."