### PR TITLE
getTokenPools: migrate to /networks/{network}/pools/search + token_address (2.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the DexPaprika MCP Server will be documented in this file.
 
+## [2.2.0] - 2026-07-15
+
+Migrate `getTokenPools` to the unified pool search endpoint. DexPaprika removed `/networks/{network}/tokens/{token_address}/pools` (HTTP 410 with `"replacement": "/networks/:network/pools/search"`), so `getTokenPools` was returning the deprecation error from 2.1.1 until this release. `/networks/{network}/pools/search` gained a `token_address` query param that restricts results to pools containing that token.
+
+### Breaking changes
+
+- **`getTokenPools` now returns rows under `results`** (was `pools` + `page_info`) with cursor pagination (`has_next_page` + `next_cursor`), matching the four tools migrated in 2.1.0. The `page` parameter is replaced by `cursor`. Rows use the canonical field names (`volume_usd_24h`, `liquidity_usd`, `price_change_percentage_24h`, ...).
+- **`inversed`/`reorder` and `paired_token_address`/`address` are dropped**: the replacement endpoint has no pair-perspective flip and no second-token pair filter (repeated `token_address` values are last-wins upstream, not a pair filter; spec is final per the API team). The parameters stay in the input schema so existing callers do not fail validation, but supplying `inversed`/`reorder: true` or a `paired_token_address`/`address` value returns a structured `DP400_UNSUPPORTED_PARAM` error with a client-side workaround (compute `1/price` for the flipped pair; filter `results[].tokens` for pair queries).
+
+### Changed
+
+- `getTokenPools` proxies `/networks/{network}/pools/search?token_address=...`, reusing the shared `src/search-mapping.js` normalization: legacy sort values (`volume_usd`, `transactions`, ...) map to the canonical search names, so existing callers keep working.
+- Tool description, server instructions, and `getCapabilities.common_pitfalls` now spell out that the token filter is network-scoped only (the cross-network `/pools/search` accepts `token_address` but silently ignores it) and that an unknown `token_address` returns an empty `results` array with HTTP 200, not an error.
+
+### Fixed
+
+- **Structured errors now actually reach clients**: error results set `isError: true` per the MCP spec. Without the flag, SDK 1.29 validates every result against the tool's `outputSchema` and rejects results that lack `structuredContent`, so any tool error on a schema-bearing tool (including the 2.1.1 deprecation-aware 410 errors) surfaced as an opaque JSON-RPC `-32602 Output validation error` instead of the structured `code`/`suggestion` payload. Found while testing the unsupported-parameter errors in this release.
+
 ## [2.1.3] - 2026-07-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Migrate `getTokenPools` to the unified pool search endpoint. DexPaprika removed 
 ### Breaking changes
 
 - **`getTokenPools` now returns rows under `results`** (was `pools` + `page_info`) with cursor pagination (`has_next_page` + `next_cursor`), matching the four tools migrated in 2.1.0. The `page` parameter is replaced by `cursor`. Rows use the canonical field names (`volume_usd_24h`, `liquidity_usd`, `price_change_percentage_24h`, ...).
-- **`inversed`/`reorder` and `paired_token_address`/`address` are dropped**: the replacement endpoint has no pair-perspective flip and no second-token pair filter (repeated `token_address` values are last-wins upstream, not a pair filter; spec is final per the API team). The parameters stay in the input schema so existing callers do not fail validation, but supplying `inversed`/`reorder: true` or a `paired_token_address`/`address` value returns a structured `DP400_UNSUPPORTED_PARAM` error with a client-side workaround (compute `1/price` for the flipped pair; filter `results[].tokens` for pair queries).
+- **`inversed`/`reorder` and `paired_token_address`/`address` are dropped**: the replacement endpoint has no pair-perspective flip and no second-token pair filter (repeating `token_address` does not act as a pair filter; the API uses only one of the values, not guaranteed by order; spec is final per the API team). The parameters stay in the input schema so existing callers do not fail validation, but supplying `inversed`/`reorder: true` or a `paired_token_address`/`address` value returns a structured `DP400_UNSUPPORTED_PARAM` error with a client-side workaround (compute `1/price` for the flipped pair; filter `results[].tokens` for pair queries).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ If you prefer zero setup, point any MCP-compatible client directly at the hosted
 | Tool | Description | Required Parameters |
 |------|-------------|---------------------|
 | `getTokenDetails` | Detailed token information | `network`, `token_address` |
-| `getTokenPools` | Liquidity pools containing a token | `network`, `token_address` |
+| `getTokenPools` | Liquidity pools containing a token (network-scoped filter, `results` + cursor pagination) | `network`, `token_address` |
 | `getTokenMultiPrices` | Batched prices for up to 10 tokens | `network`, `tokens[]` |
 | `getTopTokens` | Top tokens on a network ranked by volume, liquidity, FDV, or 24h price change | `network` |
 | `filterNetworkTokens` | Filter tokens by volume, liquidity, FDV, transactions, and creation time | `network` |
@@ -163,11 +163,12 @@ const solanaJupToken = await getTokenDetails({
   token_address: "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN"
 });
 
-// Find all pools for a specific token with volume sorting:
+// Find pools containing a token (returns `results` with cursor pagination;
+// the token filter only works network-scoped):
 const jupiterPools = await getTokenPools({
   network: "solana",
   token_address: "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN",
-  order_by: "volume_usd",
+  order_by: "volume_usd_24h",
   limit: 5
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dexpaprika-mcp",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dexpaprika-mcp",
-      "version": "2.1.3",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexpaprika-mcp",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "A Model Context Protocol server for DexPaprika cryptocurrency data with network-specific pool queries",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.js
+++ b/src/index.js
@@ -118,6 +118,7 @@ const ErrorCodes = {
   DP400_TOO_MANY_TOKENS: 'DP400_TOO_MANY_TOKENS',
   DP400_INVALID_ADDRESS: 'DP400_INVALID_ADDRESS',
   DP400_MISSING_REQUIRED: 'DP400_MISSING_REQUIRED',
+  DP400_UNSUPPORTED_PARAM: 'DP400_UNSUPPORTED_PARAM',
   DP404_NOT_FOUND: 'DP404_NOT_FOUND',
   DP429_RATE_LIMIT: 'DP429_RATE_LIMIT',
 };
@@ -284,9 +285,14 @@ function jsonText(data, structuredKey) {
 function errorText(err) {
   // Structured error objects (from parseAPIError) surface their full payload so
   // agents keep the actionable code/suggestion. Plain errors fall back to message.
+  // isError: true is required: SDK 1.29 validates non-error results against the
+  // tool's outputSchema and rejects any result without structuredContent, so an
+  // error result missing the flag surfaces as an opaque JSON-RPC -32602 instead
+  // of the structured payload below.
   if (err && typeof err === 'object' && 'error' in err) {
     return {
       content: [{ type: 'text', text: JSON.stringify(err, null, 2) }],
+      isError: true,
     };
   }
   return {
@@ -294,6 +300,7 @@ function errorText(err) {
       type: 'text',
       text: `Error: ${err instanceof Error ? err.message : 'Unknown error'}`,
     }],
+    isError: true,
   };
 }
 
@@ -354,9 +361,10 @@ const SERVER_INSTRUCTIONS = [
   '- `sort_dir` (legacy: `sort`) — sort direction, "asc" or "desc".',
   '- `sort_by` (legacy: `order_by`) — sort field, tool-specific enum.',
   '',
-  '`getTokenPools` also accepts:',
-  "- `inversed` (legacy: `reorder`) — flip pool's pair perspective.",
-  '- `paired_token_address` (legacy: `address`) — filter pools that also contain this token.',
+  '`getTokenPools` no longer accepts `inversed`/`reorder` or `paired_token_address`/`address`: the endpoint it',
+  'proxied was removed and its replacement (/networks/{network}/pools/search with token_address) has no equivalent',
+  'for either. Supplying them returns a structured error with a client-side workaround. The token filter is',
+  'network-scoped only; the cross-network /pools/search ignores token_address.',
   '',
   'Pagination is 1-indexed; the server accepts `page=0` as a backward-compat alias for `page=1`.',
   '',
@@ -484,11 +492,11 @@ const OUTPUT_SCHEMAS = {
   // strict structuredContent validation accepts real upstream shapes. The outer
   // schema is .passthrough(), so the documented key (e.g. `results`) is advertised
   // while alternate upstream keys still validate. getNetworkPools,
-  // getNetworkPoolsFilter, getTopTokens, and filterNetworkTokens proxy the
-  // /pools/search and /tokens/search endpoints: they return rows under `results`
-  // with cursor pagination (has_next_page + next_cursor), not pools/tokens/data
-  // + page_info. Keeping every key optional keeps the client robust to upstream
-  // shape drift.
+  // getNetworkPoolsFilter, getTokenPools, getTopTokens, and filterNetworkTokens
+  // proxy the /pools/search and /tokens/search endpoints: they return rows under
+  // `results` with cursor pagination (has_next_page + next_cursor), not
+  // pools/tokens/data + page_info. Keeping every key optional keeps the client
+  // robust to upstream shape drift.
   search: {
     tokens: z.array(TokenSummary).optional(),
     pools: z.array(PoolSummary).optional(),
@@ -497,7 +505,7 @@ const OUTPUT_SCHEMAS = {
 
   getNetworkDexes: { dexes: z.array(DexSummary).optional(), page_info: PageInfo.optional() },
   getDexPools: { pools: z.array(PoolSummary).optional(), page_info: PageInfo.optional() },
-  getTokenPools: { pools: z.array(PoolSummary).optional(), page_info: PageInfo.optional() },
+  getTokenPools: { results: z.array(PoolSummary).optional(), has_next_page: z.boolean().optional(), next_cursor: z.string().nullable().optional(), query: z.record(z.string(), z.unknown()).optional() },
   getNetworkPools: { results: z.array(PoolSummary).optional(), has_next_page: z.boolean().optional(), next_cursor: z.string().nullable().optional(), query: z.record(z.string(), z.unknown()).optional() },
   getNetworkPoolsFilter: { results: z.array(PoolSummary).optional(), has_next_page: z.boolean().optional(), next_cursor: z.string().nullable().optional(), query: z.record(z.string(), z.unknown()).optional() },
   getTopTokens: { results: z.array(TokenSummary).optional(), has_next_page: z.boolean().optional(), next_cursor: z.string().nullable().optional(), query: z.record(z.string(), z.unknown()).optional() },
@@ -597,7 +605,9 @@ function buildCapabilitiesDocument() {
       cross_network_search: ['search with token name/symbol/address'],
     },
     common_pitfalls: [
-      '/pools (global) returns 410 Gone — use /networks/{network}/pools instead',
+      '/pools (global) returns 410 Gone: use getNetworkPools, which proxies /networks/{network}/pools/search',
+      'getTokenPools token filtering is network-scoped only: the cross-network /pools/search silently ignores token_address, and an unknown token_address returns empty results, not an error',
+      'getTokenPools no longer supports inversed/reorder or paired_token_address/address (no equivalent on /networks/{network}/pools/search); invert prices client-side and filter results[].tokens for pair queries',
       'getTokenMultiPrices is capped at 10 tokens per request',
       'getPoolTransactions from/to are UNIX timestamps; results always capped to last 7 days',
       "Token addresses must match the network (e.g., don't send a Solana address to ethereum queries)",
@@ -884,35 +894,60 @@ registerReadTool(
 );
 
 // ─── getTokenPools ───────────────────────────────────────────────────────────
+// The upstream /networks/{network}/tokens/{token_address}/pools endpoint was
+// removed (HTTP 410, replacement /networks/:network/pools/search). The pool
+// search endpoint gained a token_address filter, so this tool proxies it via
+// the same search-mapping normalization as getNetworkPools. The old
+// inversed/reorder and paired_token_address/address params have NO equivalent
+// on the new endpoint (spec is final per the API team): the params stay in the
+// schema so existing callers do not fail input validation, but supplying them
+// returns a structured error with a client-side workaround instead of
+// silently returning data that does not match the request.
 registerReadTool(
   'getTokenPools',
-  'Get liquidity pools containing a token. REQUIRED: network, token_address. OPTIONAL: page, limit, sort_dir/sort, sort_by/order_by, inversed/reorder, paired_token_address/address.',
+  'Get liquidity pools containing a token on a network. Proxies /networks/{network}/pools/search with a token_address filter: rows are returned under `results` with cursor pagination (has_next_page + next_cursor). The token filter is network-scoped ONLY; the cross-network /pools/search ignores token_address, so use `search` first if you do not know the network. An unknown token_address returns an empty `results` array, not an error. The legacy inversed/reorder (pair-perspective flip) and paired_token_address/address (second-token pair filter) parameters have no equivalent on the new endpoint and return a structured error if supplied. REQUIRED: network, token_address. OPTIONAL: limit, cursor, sort_dir/sort, sort_by/order_by.',
   {
     network: z.string().describe("REQUIRED: Network ID from getNetworks (e.g., 'ethereum', 'solana')"),
-    token_address: z.string().describe('REQUIRED: Token contract address'),
-    page: z.number().optional().default(1).describe('OPTIONAL: Page number for pagination (default: 1, 1-indexed)'),
+    token_address: z.string().describe('REQUIRED: Token contract address. Results are restricted to pools on the given network containing this token. Unknown addresses return empty results, not an error.'),
     limit: z.number().optional().default(10).describe('OPTIONAL: Number of items per page (default: 10, max: 100)'),
+    cursor: z.string().optional().describe('OPTIONAL: Pagination cursor. Pass `next_cursor` from a previous response to fetch the next page. Replaces the old page number.'),
     sort_dir: z.enum(['asc', 'desc']).optional().describe("OPTIONAL (preferred): Sort direction (default: 'desc')"),
     sort: z.enum(['asc', 'desc']).optional().describe('OPTIONAL (deprecated alias of sort_dir): Sort direction'),
-    sort_by: z.enum(['volume_usd', 'price_usd', 'transactions', 'last_price_change_usd_24h', 'created_at']).optional().describe("OPTIONAL (preferred): Field to sort by (default: 'volume_usd')"),
-    order_by: z.enum(['volume_usd', 'price_usd', 'transactions', 'last_price_change_usd_24h', 'created_at']).optional().describe('OPTIONAL (deprecated alias of sort_by): Field to sort by'),
-    inversed: z.boolean().optional().describe("OPTIONAL (preferred): Flip the pool's pair perspective so the specified token becomes primary"),
-    reorder: z.boolean().optional().describe('OPTIONAL (deprecated alias of inversed): Reorder the pool'),
-    paired_token_address: z.string().optional().describe('OPTIONAL (preferred): Filter pools that also contain this token address'),
-    address: z.string().optional().describe('OPTIONAL (deprecated alias of paired_token_address): Additional token address filter'),
+    sort_by: z.enum(POOL_SORT_FIELDS).optional().describe("OPTIONAL (preferred): Field to sort by (default: 'volume_usd_24h'). Prefer the canonical *_24h names; short legacy names are still accepted."),
+    order_by: z.enum(POOL_SORT_FIELDS).optional().describe('OPTIONAL (deprecated alias of sort_by): Field to sort by'),
+    inversed: z.boolean().optional().describe('UNSUPPORTED: the replacement endpoint has no pair-perspective flip. Passing true returns a structured error; invert prices client-side (1/price) instead.'),
+    reorder: z.boolean().optional().describe('UNSUPPORTED (deprecated alias of inversed): passing true returns a structured error.'),
+    paired_token_address: z.string().optional().describe('UNSUPPORTED: the replacement endpoint cannot filter by a second token. Passing it returns a structured error; filter results[].tokens client-side for pair queries.'),
+    address: z.string().optional().describe('UNSUPPORTED (deprecated alias of paired_token_address): passing it returns a structured error.'),
   },
   async (args) => {
     try {
-      const { network, token_address } = args;
-      const page = coercePage(args.page);
-      const limit = args.limit ?? 10;
-      const direction = args.sort_dir ?? args.sort ?? 'desc';
-      const field = args.sort_by ?? args.order_by ?? 'volume_usd';
-      const flip = args.inversed ?? args.reorder; // may be undefined
-      const paired = args.paired_token_address ?? args.address; // may be undefined
-      let endpoint = `/networks/${network}/tokens/${token_address}/pools?page=${page}&limit=${limit}&sort=${direction}&order_by=${field}`;
-      if (flip !== undefined) endpoint += `&reorder=${flip}`;
-      if (paired) endpoint += `&address=${encodeURIComponent(paired)}`;
+      const { network } = args;
+      const flip = args.inversed ?? args.reorder;
+      if (flip === true) {
+        return errorText(buildErrorResponse(
+          ErrorCodes.DP400_UNSUPPORTED_PARAM,
+          "'inversed'/'reorder' is no longer supported: the API removed /networks/{network}/tokens/{token_address}/pools and its replacement /networks/{network}/pools/search has no pair-perspective flip",
+          false,
+          "Retry without 'inversed'/'reorder'. Prices come back in the pool's default perspective; compute 1/price client-side if you need the flipped pair.",
+          undefined,
+          { parameter: 'inversed', legacy_alias: 'reorder' },
+        ));
+      }
+      const paired = args.paired_token_address ?? args.address;
+      if (typeof paired === 'string' && paired !== '') {
+        return errorText(buildErrorResponse(
+          ErrorCodes.DP400_UNSUPPORTED_PARAM,
+          "'paired_token_address'/'address' is no longer supported: the replacement /networks/{network}/pools/search accepts a single token_address filter and has no second-token pair filter",
+          false,
+          "Retry with token_address only, then filter results[].tokens client-side for pools that also contain the second token.",
+          undefined,
+          { parameter: 'paired_token_address', legacy_alias: 'address' },
+        ));
+      }
+      // buildPoolSearchParams picks up token_address, limit, cursor, and the
+      // normalized sort params from args.
+      const endpoint = `/networks/${network}/pools/search${toQueryString(buildPoolSearchParams(args))}`;
       return jsonText(await fetchFromAPI(endpoint));
     } catch (error) {
       return errorText(error);

--- a/src/search-mapping.js
+++ b/src/search-mapping.js
@@ -24,8 +24,9 @@
  * pools containing that token, so getTokenPools routes through
  * buildPoolSearchParams too. Two caveats, both verified live (2026-07-15):
  * the filter is network-scoped only (the cross-network /pools/search accepts
- * token_address but silently ignores it), and repeated token_address values
- * are last-wins upstream, NOT a pair filter.
+ * token_address but silently ignores it), and repeating token_address does
+ * not act as a pair filter; the API uses only one of the values (not
+ * guaranteed by order).
  */
 
 const POOL_SORT_CANONICAL = new Set([

--- a/src/search-mapping.js
+++ b/src/search-mapping.js
@@ -17,6 +17,15 @@
  * Verified live against api.dexpaprika.com (2026-06-30): every canonical value
  * below returns 200 and sorts correctly; the legacy values 400. tokens/search
  * does not support price_usd ordering (400), so it falls back to volume.
+ *
+ * 2026-07-15: /networks/{network}/tokens/{token_address}/pools was removed the
+ * same way (HTTP 410, replacement /networks/:network/pools/search). The pool
+ * search endpoint gained a token_address query param that restricts results to
+ * pools containing that token, so getTokenPools routes through
+ * buildPoolSearchParams too. Two caveats, both verified live (2026-07-15):
+ * the filter is network-scoped only (the cross-network /pools/search accepts
+ * token_address but silently ignores it), and repeated token_address values
+ * are last-wins upstream, NOT a pair filter.
  */
 
 const POOL_SORT_CANONICAL = new Set([
@@ -100,6 +109,9 @@ export function buildPoolSearchParams(args) {
   };
   if (args.limit !== undefined && args.limit !== null) params.limit = args.limit;
   if (typeof args.cursor === 'string' && args.cursor !== '') params.cursor = args.cursor;
+  // token_address restricts results to pools containing that token (used by
+  // getTokenPools). Network-scoped /pools/search only; see the header comment.
+  if (typeof args.token_address === 'string' && args.token_address !== '') params.token_address = args.token_address;
   for (const [legacy, canonical] of Object.entries(POOL_FILTER_PARAM)) {
     const v = args[legacy];
     if (v !== undefined && v !== null) params[canonical] = v;

--- a/src/test_methods.js
+++ b/src/test_methods.js
@@ -53,6 +53,7 @@ async function runTests() {
   await testEndpoint('getDexPools', '/networks/ethereum/dexes/uniswap_v3/pools');
   await testEndpoint('getPoolDetails', '/networks/ethereum/pools/0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640');
   await testEndpoint('getTokenDetails', '/networks/ethereum/tokens/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48');
+  await testEndpoint('getTokenPools', '/networks/ethereum/pools/search?token_address=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&order_by=volume_usd_24h&limit=5');
   await testEndpoint('getTopTokens', '/networks/ethereum/tokens/search?order_by=volume_usd_24h&limit=5');
   await testEndpoint('filterNetworkTokens', '/networks/ethereum/tokens/search?volume_usd_24h_min=10000000&order_by=volume_usd_24h&limit=5');
   await testEndpoint('getTokenMultiPrices', '/networks/ethereum/multi/prices?tokens=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&tokens=0xdac17f958d2ee523a2206206994597c13d831ec7');


### PR DESCRIPTION
## Why

The API removed `GET /networks/{network}/tokens/{token_address}/pools` on 2026-07-15. It now returns HTTP 410 with `{"code":410,"message":"endpoint removed","replacement":"/networks/:network/pools/search"}`, so `getTokenPools` has been returning the 2.1.1 deprecation error on every call. The replacement, `GET /networks/{network}/pools/search`, gained a `token_address` query param that restricts results to pools containing that token on that network.

## What changed

- `getTokenPools` now proxies `/networks/{network}/pools/search?token_address=...`, reusing the shared `src/search-mapping.js` normalization exactly like the four tools migrated in 2.1.0. Legacy sort values (`volume_usd`, `transactions`, ...) still map to the canonical names, and network synonyms (`eth`, `sol`, ...) still resolve.
- Response shape follows the search contract: rows under `results` with cursor pagination (`has_next_page` + `next_cursor`), `page` replaced by `cursor`. Output schema updated to match.
- `inversed`/`reorder` (pair-perspective flip) and `paired_token_address`/`address` (second-token pair filter) have no equivalent on the new endpoint; the spec is final per the API team. Repeating `token_address` does not act as a pair filter upstream; the API uses only one of the values (not guaranteed by order), so I did not fake one. The params stay in the input schema so existing callers pass validation, but supplying them returns a structured `DP400_UNSUPPORTED_PARAM` error with a client-side workaround (invert prices with `1/price`; filter `results[].tokens` for pair queries). Silently ignoring them would return data that does not match the request, which is worse for agents than an actionable error.
- Tool description, server instructions, and `getCapabilities.common_pitfalls` now state the two gotchas explicitly: the token filter is network-scoped only (the cross-network `/pools/search` accepts `token_address` but silently ignores it), and an unknown `token_address` returns an empty `results` array with HTTP 200, not an error.
- Bug fix found while testing: error results never set `isError: true`, and SDK 1.29 rejects any result without `structuredContent` on a tool that has an `outputSchema`. Every structured error on a schema-bearing tool, including the 2.1.1 deprecation-aware 410 errors, surfaced as an opaque JSON-RPC `-32602 Output validation error` instead of the `code`/`suggestion` payload. `errorText()` now sets the flag.
- Version bumped to 2.2.0 (behavior change), CHANGELOG entry added. Not published to npm yet; the `prepack` hook builds `dist/` automatically at publish time.

## Verification

All against live `api.dexpaprika.com` today:

- Old endpoint returns 410 with the replacement body (curl).
- `GET /networks/ethereum/pools/search?token_address=0xc02aaa...&limit=3` returns 3/3 pools containing WETH; the second cursor page is also fully filtered with no overlap.
- Legacy `order_by=volume_usd` sent raw to the search endpoint returns 400, so the mapping layer is load-bearing.
- Bogus `token_address` returns HTTP 200 with empty `results`, `has_next_page: false`.
- Full stdio smoke over JSON-RPC (initialize, tools/list, tools/call), 16/16 checks: WETH pools filtered, cursor + `query` echo present, `content[0].text` matches `structuredContent`, legacy sort plus `eth` synonym normalized (`query.order_by` echoes `volume_usd_24h`), `inversed: true` and `paired_token_address` return `DP400_UNSUPPORTED_PARAM` with `isError: true`, unknown network surfaces the structured `DP400_INVALID_NETWORK` payload, `inversed: false` (the old default) still succeeds, bogus token returns empty results.
- `npm test` passes; `npm run test:api` passes 14/14 including a new `getTokenPools` line hitting the search endpoint.

After merge this needs an `npm publish` with OTP; `prepack` builds `dist/`.

Maintainer note: squash-merge this PR with a clean commit message.
