### PR TITLE
Rewrite tool descriptions for AI tool-selection (intent-first)

### DIFF
--- a/.github/smoke.mjs
+++ b/.github/smoke.mjs
@@ -5,7 +5,7 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 
-const MIN_TOOLS = 14; // lenient floor (package has 16 on v1.x, 17 on v2.x)
+const MIN_TOOLS = 14; // lenient floor (package exposes 16 read tools)
 const CORE_TOOLS = ['getNetworks', 'getNetworkPools', 'getCapabilities'];
 
 const transport = new StdioClientTransport({ command: 'node', args: ['src/index.js'] });

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npx dexpaprika-mcp@latest
 
 DexPaprika MCP connects Claude to live DEX data across multiple blockchains. No API keys required. [Installation](#installation) | [Configuration](#claude-desktop-integration) | [API Reference](https://docs.dexpaprika.com/introduction)
 
-> **Prefer zero setup?** Use the hosted MCP server at [mcp.dexpaprika.com](https://mcp.dexpaprika.com): no installation, no API key, same 17 tools. See [Hosted Alternative](#hosted-alternative-no-installation) for transport endpoints.
+> **Prefer zero setup?** Use the hosted MCP server at [mcp.dexpaprika.com](https://mcp.dexpaprika.com): no installation, no API key, the same data tools plus `submitFeedback`. See [Hosted Alternative](#hosted-alternative-no-installation) for transport endpoints.
 
 ## Version 1.3.0 Update Highlights
 
@@ -107,7 +107,7 @@ If you prefer zero setup, point any MCP-compatible client directly at the hosted
 }
 ```
 
-## Available Tools (17)
+## Available Tools (16)
 
 ### Discovery
 
@@ -144,12 +144,6 @@ If you prefer zero setup, point any MCP-compatible client directly at the hosted
 | `getTokenMultiPrices` | Batched prices for up to 10 tokens | `network`, `tokens[]` |
 | `getTopTokens` | Top tokens on a network ranked by volume, liquidity, FDV, or 24h price change | `network` |
 | `filterNetworkTokens` | Filter tokens by volume, liquidity, FDV, transactions, and creation time | `network` |
-
-### Feedback
-
-| Tool | Description | Required Parameters |
-|------|-------------|---------------------|
-| `submitFeedback` | Report unexpected tool behavior, missing data, or docs gaps straight to the team | `goal` |
 
 ### Example Usage
 

--- a/src/index.js
+++ b/src/index.js
@@ -228,7 +228,7 @@ async function buildCapabilitiesDocument() {
     tools: [
       {
         name: "getNetworks",
-        description: "Get the full list of blockchain networks DexPaprika indexes, each with 24h volume, transaction counts, and pool counts. Use when asked \"which chains do you support?\", \"is Base/Solana/Arbitrum covered?\", or whenever you need the exact network slug before calling any other tool. Start here (or getCapabilities) since every other DEX query requires a valid network id. No parameters beyond rationale.",
+        description: "Get the full list of blockchain networks DexPaprika indexes, each with 24h volume, transaction counts, and pool counts. Use when asked 'which chains do you support?', 'is Base/Solana/Arbitrum covered?', or whenever you need the exact network slug before calling any other tool. Start here (or getCapabilities) since every other DEX query requires a valid network id. No parameters beyond rationale.",
         category: "discovery",
         parameters: {},
         returns: { type: "array", items: "Network" },
@@ -236,7 +236,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getCapabilities",
-        description: "Get an agent onboarding guide: supported workflows, network name synonyms, common pitfalls, and recommended call sequences. Use when asked \"how do I use this API?\", \"what order should I call things in?\", or before your first query so you can map user words like \"eth\" to the canonical network slug. This returns static onboarding docs, not live market data; read it once at the start of a session. No parameters beyond rationale.",
+        description: "Get an agent onboarding guide: supported workflows, network name synonyms, common pitfalls, and recommended call sequences. Use when asked 'how do I use this API?', 'what order should I call things in?', or before your first query so you can map user words like 'eth' to the canonical network slug. This returns static onboarding docs, not live market data; read it once at the start of a session. No parameters beyond rationale.",
         category: "discovery",
         parameters: {},
         returns: { type: "object" },
@@ -244,7 +244,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getNetworkDexes",
-        description: "List the DEXes (exchanges) operating on one specific network, such as Uniswap on ethereum or Raydium on solana. Use when asked \"which DEXes are on Base?\", \"does Solana have Orca?\", or when you need a DEX name to pass into getDexPools. Scope is a single network; call getNetworks first if you do not know the slug. Requires network.",
+        description: "List the DEXes (exchanges) operating on one specific network, such as Uniswap on ethereum or Raydium on solana. Use when asked 'which DEXes are on Base?', 'does Solana have Orca?', or when you need a DEX name to pass into getDexPools. Scope is a single network; call getNetworks first if you do not know the slug. Requires network.",
         category: "dexes",
         parameters: {
           network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
@@ -258,7 +258,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getNetworkPools",
-        description: "Get the top liquidity pools on one network, ranked by 24h volume by default. Use when asked \"what are the biggest/hottest pools on ethereum?\", \"top trading pairs on Base right now\", or \"most active pools on Solana\". This is the primary pool-discovery tool for a whole chain; narrow to one exchange with getDexPools, or set numeric thresholds with getNetworkPoolsFilter. Requires network; rows return under `results` with cursor pagination.",
+        description: "Get the top liquidity pools on one network, ranked by 24h volume by default. Use when asked 'what are the biggest/hottest pools on ethereum?', 'top trading pairs on Base right now', or 'most active pools on Solana'. This is the primary pool-discovery tool for a whole chain; narrow to one exchange with getDexPools, or set numeric thresholds with getNetworkPoolsFilter. Requires network; rows return under `results` with cursor pagination.",
         category: "pools",
         parameters: {
           network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
@@ -272,7 +272,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getDexPools",
-        description: "Get the pools that belong to one specific DEX on one network, such as all Uniswap v3 pools on ethereum. Use when asked \"show me Raydium pools\", \"top pairs on PancakeSwap\", or \"liquidity on Orca\". Narrower than getNetworkPools (a single exchange, not the whole chain); get the DEX name from getNetworkDexes or search first. Requires network and dex.",
+        description: "Get the pools that belong to one specific DEX on one network, such as all Uniswap v3 pools on ethereum. Use when asked 'show me Raydium pools', 'top pairs on PancakeSwap', or 'liquidity on Orca'. Narrower than getNetworkPools (a single exchange, not the whole chain); get the DEX name from getNetworkDexes or search first. Requires network and dex.",
         category: "pools",
         parameters: {
           network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
@@ -287,7 +287,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getNetworkPoolsFilter",
-        description: "Get pools on one network filtered by exact thresholds for volume, liquidity, transaction count, or creation time. Use when asked \"pools with over $1M liquidity on Base\", \"pools created in the last 24h\", or \"high-volume low-liquidity pairs\". Choose this over getNetworkPools when the user gives numeric constraints or a time window rather than just \"top\". Requires network; rows return under `results` with cursor pagination.",
+        description: "Get pools on one network filtered by exact thresholds for volume, liquidity, transaction count, or creation time. Use when asked 'pools with over $1M liquidity on Base', 'pools created in the last 24h', or 'high-volume low-liquidity pairs'. Choose this over getNetworkPools when the user gives numeric constraints or a time window rather than just 'top'. Requires network; rows return under `results` with cursor pagination.",
         category: "pools",
         parameters: {
           network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
@@ -311,7 +311,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "filterNetworkTokens",
-        description: "Get tokens on one network filtered by exact thresholds for volume, liquidity, FDV, transactions, or creation time. Use when asked \"tokens with FDV over $10M on Base\", \"newly created tokens today\", or \"low-liquidity high-volume tokens\". Choose this over getTopTokens when the user gives numeric constraints or a time window rather than a simple ranking. Requires network; rows return under `results` with cursor pagination.",
+        description: "Get tokens on one network filtered by exact thresholds for volume, liquidity, FDV, transactions, or creation time. Use when asked 'tokens with FDV over $10M on Base', 'newly created tokens today', or 'low-liquidity high-volume tokens'. Choose this over getTopTokens when the user gives numeric constraints or a time window rather than a simple ranking. Requires network; rows return under `results` with cursor pagination.",
         category: "tokens",
         parameters: {
           network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
@@ -334,7 +334,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getTopTokens",
-        description: "Get the top tokens on one network ranked by volume, liquidity, transactions, FDV, or 24h price change. Use when asked \"top gainers on Solana\", \"highest-volume tokens on Base\", or \"biggest tokens by FDV on ethereum\". Ranking by raw price is not supported and silently falls back to volume; for arbitrary numeric filters use filterNetworkTokens. Requires network; rows return under `results` with cursor pagination.",
+        description: "Get the top tokens on one network ranked by volume, liquidity, transactions, FDV, or 24h price change. Use when asked 'top gainers on Solana', 'highest-volume tokens on Base', or 'biggest tokens by FDV on ethereum'. Ranking by raw price is not supported and silently falls back to volume; for arbitrary numeric filters use filterNetworkTokens. Requires network; rows return under `results` with cursor pagination.",
         category: "tokens",
         parameters: {
           network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
@@ -349,7 +349,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getPoolDetails",
-        description: "Get full details for one pool by its address: the two tokens, current price, liquidity, 24h volume, and transaction counts. Use when asked \"what's the price/TVL of this pool?\", \"details for pool 0x...\", or after search or getNetworkPools surfaces a pool you want to inspect. Returns the live current snapshot only; use getPoolOHLCV for historical candles or getPoolTransactions for the raw swap feed. Requires network and pool_address.",
+        description: "Get full details for one pool by its address: the two tokens, current price, liquidity, 24h volume, and transaction counts. Use when asked 'what's the price/TVL of this pool?', 'details for pool 0x...', or after search or getNetworkPools surfaces a pool you want to inspect. Returns the live current snapshot only; use getPoolOHLCV for historical candles or getPoolTransactions for the raw swap feed. Requires network and pool_address.",
         category: "pools",
         parameters: {
           network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
@@ -361,7 +361,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getPoolOHLCV",
-        description: "Get historical open/high/low/close/volume candles for one pool across a date range and interval (1m up to 1d). Use when asked \"price history of this pair\", \"hourly chart for the last week\", \"candles since Jan 1\", or for backtesting and technical analysis. This is historical time-series data; use getPoolDetails for the single current price. Requires network, pool_address, and start.",
+        description: "Get historical open/high/low/close/volume candles for one pool across a date range and interval (1m up to 1d). Use when asked 'price history of this pair', 'hourly chart for the last week', 'candles since Jan 1', or for backtesting and technical analysis. This is historical time-series data; use getPoolDetails for the single current price. Requires network, pool_address, and start.",
         category: "pools",
         parameters: {
           network: { type: "string", required: true },
@@ -377,7 +377,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getPoolTransactions",
-        description: "Get the recent individual swap transactions for one pool, newest first, optionally filtered to a from/to window (Unix epoch seconds, last 7 days max). Use when asked \"recent trades on this pool\", \"who swapped in the last hour\", or \"raw transaction feed\". These are per-trade records, not aggregated candles (use getPoolOHLCV) or a summary (use getPoolDetails). Requires network and pool_address.",
+        description: "Get the recent individual swap transactions for one pool, newest first, optionally filtered to a from/to window (Unix epoch seconds, last 7 days max). Use when asked 'recent trades on this pool', 'who swapped in the last hour', or 'raw transaction feed'. These are per-trade records, not aggregated candles (use getPoolOHLCV) or a summary (use getPoolDetails). Requires network and pool_address.",
         category: "pools",
         parameters: {
           network: { type: "string", required: true },
@@ -404,7 +404,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getTokenPools",
-        description: "Get the liquidity pools that contain a specific token on one network. Use when asked \"which pools hold WETH on ethereum?\", \"where can I trade this token\", or \"liquidity venues for 0x...\". The token filter is network-scoped only, so run search first if you do not know the network; an unknown token_address returns an empty `results` array, not an error. Requires network and token_address; rows return under `results` with cursor pagination.",
+        description: "Get the liquidity pools that contain a specific token on one network. Use when asked 'which pools hold WETH on ethereum?', 'where can I trade this token', or 'liquidity venues for 0x...'. The token filter is network-scoped only, so run search first if you do not know the network; an unknown token_address returns an empty `results` array, not an error. Requires network and token_address; rows return under `results` with cursor pagination.",
         category: "tokens",
         parameters: {
           network: { type: "string", required: true },
@@ -421,7 +421,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getTokenMultiPrices",
-        description: "Get current USD prices for up to 10 tokens on the same network in one batched call. Use when asked \"prices for these tokens\", \"compare the price of X, Y and Z\", or when building a portfolio or dashboard snapshot. Tokens that cannot be priced come back in `missing_tokens` rather than being dropped, so check that list to catch partial failures; for one token with full metadata use getTokenDetails. Requires network and tokens.",
+        description: "Get current USD prices for up to 10 tokens on the same network in one batched call. Use when asked 'prices for these tokens', 'compare the price of X, Y and Z', or when building a portfolio or dashboard snapshot. Tokens that cannot be priced come back in `missing_tokens` rather than being dropped, so check that list to catch partial failures; for one token with full metadata use getTokenDetails. Requires network and tokens.",
         category: "tokens",
         parameters: {
           network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
@@ -432,7 +432,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "search",
-        description: "Search across ALL networks at once for tokens, pools, and DEXes by name, symbol, or address, returning three arrays: tokens, pools, dexes. Use when asked \"find PEPE\", \"what's the address for USDC\", or whenever you do not yet know which network something lives on. This is the cross-chain entry point; once you have a network slug, switch to the network-scoped tools. Requires query.",
+        description: "Search across ALL networks at once for tokens, pools, and DEXes by name, symbol, or address, returning three arrays: tokens, pools, dexes. Use when asked 'find PEPE', 'what's the address for USDC', or whenever you do not yet know which network something lives on. This is the cross-chain entry point; once you have a network slug, switch to the network-scoped tools. Requires query.",
         category: "search",
         parameters: {
           query: { type: "string", required: true, description: "Search term", example: "uniswap" }
@@ -442,7 +442,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getStats",
-        description: "Get platform-wide totals for DexPaprika: number of networks, DEXes, pools, and tokens indexed. Use when asked \"how much data do you cover?\", \"how many chains or pools total?\", or for a one-line coverage summary. These are ecosystem-wide counts, not per-network figures; use getNetworks for per-chain breakdowns. No parameters beyond rationale.",
+        description: "Get platform-wide totals for DexPaprika: number of networks, DEXes, pools, and tokens indexed. Use when asked 'how much data do you cover?', 'how many chains or pools total?', or for a one-line coverage summary. These are ecosystem-wide counts, not per-network figures; use getNetworks for per-chain breakdowns. No parameters beyond rationale.",
         category: "utils",
         parameters: {},
         returns: { type: "object", properties: ["chains", "factories", "pools", "tokens"] },

--- a/src/index.js
+++ b/src/index.js
@@ -311,15 +311,8 @@ const ANNOTATIONS_READ_ONLY = {
   destructiveHint: false,
   openWorldHint: true,
 };
-const ANNOTATIONS_WRITE_FEEDBACK = {
-  readOnlyHint: false,
-  idempotentHint: false,
-  destructiveHint: false,
-  openWorldHint: false,
-};
-
 // ─────────────────────────────────────────────────────────────────────────────
-// rationale field — REQUIRED on every read tool (all tools except submitFeedback).
+// rationale field — REQUIRED on every read tool.
 // Accepted by the handler and IGNORED (no analytics sink; no D1 in stdio).
 // ─────────────────────────────────────────────────────────────────────────────
 const RATIONALE_DESCRIPTION =
@@ -350,8 +343,6 @@ const SERVER_INSTRUCTIONS = [
   '- "User asked for SOL price; calling getTokenDetails to fetch current USD value."',
   '- "Building a portfolio dashboard; need top pools for WETH on ethereum to estimate liquidity."',
   '- "Backtesting USDC/WETH spread; fetching 24h OHLCV at 1h interval."',
-  '',
-  '`submitFeedback` is the exception — it has its own `goal`/`expected`/`observed` fields which serve as the rationale.',
   '',
   '## Tool discovery',
   'Start with `getNetworks` (discover supported chains) or `getCapabilities` (agent-onboarding doc: network synonyms, workflow patterns, common pitfalls). Both are free and have no parameters beyond rationale.',
@@ -553,13 +544,6 @@ const OUTPUT_SCHEMAS = {
     prices: z.array(PriceEntry).describe('USD prices for the requested tokens, in input order.'),
     missing_tokens: z.array(z.string()).optional().describe('Input tokens that upstream could not price (invalid address, no liquidity, unknown contract). Empty array when all input tokens were resolved.'),
   },
-
-  submitFeedback: {
-    ok: z.boolean().describe('True if the feedback was accepted.'),
-    tracking_id: z.string().nullable().optional().describe('Stable id agents can reference in follow-up submissions; null if persistence failed.'),
-    message: z.string(),
-    severity: z.enum(['blocker', 'major', 'minor', 'nit']).optional(),
-  },
 };
 
 // Build the permissive (outer-passthrough) outputSchema for a tool name.
@@ -579,7 +563,7 @@ function buildCapabilitiesDocument() {
     name: SERVER_CANONICAL_NAME,
     aliases: SERVER_ALIASES,
     server: { name: 'DexPaprika MCP', version: SERVER_VERSION },
-    tools_count: 17,
+    tools_count: 16,
     stats: {
       networks: 36,
       tokens_approx: 33_000_000,
@@ -1094,36 +1078,6 @@ registerReadTool(
     } catch (error) {
       return errorText(error);
     }
-  },
-);
-
-// ─── submitFeedback (17th tool, NO rationale, write annotation) ──────────────
-// stdio has no D1; we degrade to a structured ack instead of a DB INSERT.
-server.registerTool(
-  'submitFeedback',
-  {
-    description:
-      "Report a problem back to the DexPaprika team when a tool got you stuck, returned something unexpected, lacked data you needed, or behaved differently than documented. Use whenever you hit a dead end, a response shape surprised you, or coverage was missing; even partial feedback helps and every submission is read. Low friction: provide goal, expected, and observed instead of a rationale field.",
-    inputSchema: {
-      goal: z.string().min(10).max(500).describe('REQUIRED. What you were trying to accomplish (10-500 chars).'),
-      attempted_tools: z.array(z.string()).optional().describe('OPTIONAL. Tools you tried before getting stuck.'),
-      blocked_at: z.string().optional().describe('OPTIONAL. Where exactly you got blocked.'),
-      expected: z.string().max(500).optional().describe('OPTIONAL. What you expected to happen (max 500 chars).'),
-      observed: z.string().max(500).optional().describe('OPTIONAL. What actually happened (max 500 chars).'),
-      severity: z.enum(['blocker', 'major', 'minor', 'nit']).optional().default('minor').describe("OPTIONAL. Impact severity (default: 'minor')."),
-    },
-    outputSchema: outputSchemaFor('submitFeedback'),
-    annotations: ANNOTATIONS_WRITE_FEEDBACK,
-  },
-  async ({ severity }) => {
-    // No D1 / no analytics sink in the self-host build. Accept and acknowledge.
-    const ack = {
-      ok: true,
-      tracking_id: null,
-      message: 'Thanks. This self-host build does not persist feedback; please open an issue at https://github.com/coinpaprika/dexpaprika-mcp for anything actionable.',
-      severity: severity ?? 'minor',
-    };
-    return jsonText(ack);
   },
 );
 

--- a/src/index.js
+++ b/src/index.js
@@ -217,7 +217,7 @@ async function buildCapabilitiesDocument() {
   return {
     service: "dexpaprika",
     version: SERVER_VERSION,
-    description: "DeFi analytics across 33 blockchain networks",
+    description: "DeFi analytics across 36 blockchain networks",
     server: {
       name: "DexPaprika MCP Server",
       version: SERVER_VERSION,
@@ -228,7 +228,7 @@ async function buildCapabilitiesDocument() {
     tools: [
       {
         name: "getNetworks",
-        description: "List all supported blockchain networks",
+        description: "Get the full list of blockchain networks DexPaprika indexes, each with 24h volume, transaction counts, and pool counts. Use when asked \"which chains do you support?\", \"is Base/Solana/Arbitrum covered?\", or whenever you need the exact network slug before calling any other tool. Start here (or getCapabilities) since every other DEX query requires a valid network id. No parameters beyond rationale.",
         category: "discovery",
         parameters: {},
         returns: { type: "array", items: "Network" },
@@ -236,7 +236,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getCapabilities",
-        description: "Return server capabilities, workflow patterns, network synonyms, common pitfalls, and best-practice sequences",
+        description: "Get an agent onboarding guide: supported workflows, network name synonyms, common pitfalls, and recommended call sequences. Use when asked \"how do I use this API?\", \"what order should I call things in?\", or before your first query so you can map user words like \"eth\" to the canonical network slug. This returns static onboarding docs, not live market data; read it once at the start of a session. No parameters beyond rationale.",
         category: "discovery",
         parameters: {},
         returns: { type: "object" },
@@ -244,7 +244,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getNetworkDexes",
-        description: "Get available DEXes on a specific network",
+        description: "List the DEXes (exchanges) operating on one specific network, such as Uniswap on ethereum or Raydium on solana. Use when asked \"which DEXes are on Base?\", \"does Solana have Orca?\", or when you need a DEX name to pass into getDexPools. Scope is a single network; call getNetworks first if you do not know the slug. Requires network.",
         category: "dexes",
         parameters: {
           network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
@@ -258,7 +258,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getNetworkPools",
-        description: "Get top liquidity pools on a network",
+        description: "Get the top liquidity pools on one network, ranked by 24h volume by default. Use when asked \"what are the biggest/hottest pools on ethereum?\", \"top trading pairs on Base right now\", or \"most active pools on Solana\". This is the primary pool-discovery tool for a whole chain; narrow to one exchange with getDexPools, or set numeric thresholds with getNetworkPoolsFilter. Requires network; rows return under `results` with cursor pagination.",
         category: "pools",
         parameters: {
           network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
@@ -272,7 +272,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getDexPools",
-        description: "Get pools from a specific DEX on a network",
+        description: "Get the pools that belong to one specific DEX on one network, such as all Uniswap v3 pools on ethereum. Use when asked \"show me Raydium pools\", \"top pairs on PancakeSwap\", or \"liquidity on Orca\". Narrower than getNetworkPools (a single exchange, not the whole chain); get the DEX name from getNetworkDexes or search first. Requires network and dex.",
         category: "pools",
         parameters: {
           network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
@@ -287,7 +287,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getNetworkPoolsFilter",
-        description: "Filter pools by volume, liquidity, transactions, and creation time",
+        description: "Get pools on one network filtered by exact thresholds for volume, liquidity, transaction count, or creation time. Use when asked \"pools with over $1M liquidity on Base\", \"pools created in the last 24h\", or \"high-volume low-liquidity pairs\". Choose this over getNetworkPools when the user gives numeric constraints or a time window rather than just \"top\". Requires network; rows return under `results` with cursor pagination.",
         category: "pools",
         parameters: {
           network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
@@ -311,7 +311,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "filterNetworkTokens",
-        description: "Filter tokens by volume, liquidity, FDV, transactions, and creation time",
+        description: "Get tokens on one network filtered by exact thresholds for volume, liquidity, FDV, transactions, or creation time. Use when asked \"tokens with FDV over $10M on Base\", \"newly created tokens today\", or \"low-liquidity high-volume tokens\". Choose this over getTopTokens when the user gives numeric constraints or a time window rather than a simple ranking. Requires network; rows return under `results` with cursor pagination.",
         category: "tokens",
         parameters: {
           network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
@@ -334,7 +334,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getTopTokens",
-        description: "Get top tokens on a network ranked by volume, price, liquidity, or activity",
+        description: "Get the top tokens on one network ranked by volume, liquidity, transactions, FDV, or 24h price change. Use when asked \"top gainers on Solana\", \"highest-volume tokens on Base\", or \"biggest tokens by FDV on ethereum\". Ranking by raw price is not supported and silently falls back to volume; for arbitrary numeric filters use filterNetworkTokens. Requires network; rows return under `results` with cursor pagination.",
         category: "tokens",
         parameters: {
           network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
@@ -349,7 +349,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getPoolDetails",
-        description: "Get detailed info about a pool",
+        description: "Get full details for one pool by its address: the two tokens, current price, liquidity, 24h volume, and transaction counts. Use when asked \"what's the price/TVL of this pool?\", \"details for pool 0x...\", or after search or getNetworkPools surfaces a pool you want to inspect. Returns the live current snapshot only; use getPoolOHLCV for historical candles or getPoolTransactions for the raw swap feed. Requires network and pool_address.",
         category: "pools",
         parameters: {
           network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
@@ -361,7 +361,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getPoolOHLCV",
-        description: "Get historical price data (OHLCV) for a pool",
+        description: "Get historical open/high/low/close/volume candles for one pool across a date range and interval (1m up to 1d). Use when asked \"price history of this pair\", \"hourly chart for the last week\", \"candles since Jan 1\", or for backtesting and technical analysis. This is historical time-series data; use getPoolDetails for the single current price. Requires network, pool_address, and start.",
         category: "pools",
         parameters: {
           network: { type: "string", required: true },
@@ -377,7 +377,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getPoolTransactions",
-        description: "Get recent transactions for a pool",
+        description: "Get the recent individual swap transactions for one pool, newest first, optionally filtered to a from/to window (Unix epoch seconds, last 7 days max). Use when asked \"recent trades on this pool\", \"who swapped in the last hour\", or \"raw transaction feed\". These are per-trade records, not aggregated candles (use getPoolOHLCV) or a summary (use getPoolDetails). Requires network and pool_address.",
         category: "pools",
         parameters: {
           network: { type: "string", required: true },
@@ -393,7 +393,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getTokenDetails",
-        description: "Get detailed information about a token",
+        description: "Get metadata and multi-timeframe price and volume metrics for one token by its contract address on one network, including website, Twitter and Telegram links. Use for 'price and volume for 0x... on Base', 'tell me about this token'. If you only have a symbol (e.g. WETH) and not an address, call search first to resolve it, then use this. For several tokens at once use getTokenMultiPrices. Requires network and token_address.",
         category: "tokens",
         parameters: {
           network: { type: "string", required: true },
@@ -404,7 +404,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getTokenPools",
-        description: "Get liquidity pools containing a token",
+        description: "Get the liquidity pools that contain a specific token on one network. Use when asked \"which pools hold WETH on ethereum?\", \"where can I trade this token\", or \"liquidity venues for 0x...\". The token filter is network-scoped only, so run search first if you do not know the network; an unknown token_address returns an empty `results` array, not an error. Requires network and token_address; rows return under `results` with cursor pagination.",
         category: "tokens",
         parameters: {
           network: { type: "string", required: true },
@@ -421,7 +421,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getTokenMultiPrices",
-        description: "Batch fetch prices for up to 10 tokens",
+        description: "Get current USD prices for up to 10 tokens on the same network in one batched call. Use when asked \"prices for these tokens\", \"compare the price of X, Y and Z\", or when building a portfolio or dashboard snapshot. Tokens that cannot be priced come back in `missing_tokens` rather than being dropped, so check that list to catch partial failures; for one token with full metadata use getTokenDetails. Requires network and tokens.",
         category: "tokens",
         parameters: {
           network: { type: "string", required: true, description: "Network ID", example: "ethereum" },
@@ -432,7 +432,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "search",
-        description: "Search across ALL networks for tokens, pools, and DEXes by name, symbol, or address",
+        description: "Search across ALL networks at once for tokens, pools, and DEXes by name, symbol, or address, returning three arrays: tokens, pools, dexes. Use when asked \"find PEPE\", \"what's the address for USDC\", or whenever you do not yet know which network something lives on. This is the cross-chain entry point; once you have a network slug, switch to the network-scoped tools. Requires query.",
         category: "search",
         parameters: {
           query: { type: "string", required: true, description: "Search term", example: "uniswap" }
@@ -442,7 +442,7 @@ async function buildCapabilitiesDocument() {
       },
       {
         name: "getStats",
-        description: "Get high-level statistics about the DexPaprika ecosystem",
+        description: "Get platform-wide totals for DexPaprika: number of networks, DEXes, pools, and tokens indexed. Use when asked \"how much data do you cover?\", \"how many chains or pools total?\", or for a one-line coverage summary. These are ecosystem-wide counts, not per-network figures; use getNetworks for per-chain breakdowns. No parameters beyond rationale.",
         category: "utils",
         parameters: {},
         returns: { type: "object", properties: ["chains", "factories", "pools", "tokens"] },


### PR DESCRIPTION
Rewrites all 16 tool descriptions to be intent-first so a model reliably picks the right tool from name + description. Each leads with the answer, adds a "Use when asked '...'" clause with real query phrases, and guards sibling-tool confusion (current vs historical, single vs batch/multi, whole-network vs single-DEX, cross-chain search vs network-scoped tools). Also refreshed a stale "33 blockchain networks" to 36.

Matches the canonical set now deployed on the hosted DexPaprika MCP worker, so hosted and self-hosted present identical descriptions. Validated with a PL+EN tool-selection eval; descriptions-only, no API/logic change, node -c passes.