### PR TITLE
release 2.3.0: intent-first descriptions + remove submitFeedback (publish to npm)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the DexPaprika MCP Server will be documented in this file.
 
+## [2.3.0] - 2026-07-27
+
+### Removed
+
+- **`submitFeedback` tool removed from the self-host build.** The stdio build had no analytics sink, so the tool only returned an acknowledgement and persisted nothing. Feedback collection now lives solely on the hosted MCP (`mcp.dexpaprika.com`), where it is actually stored. Self-host now exposes 16 read tools; the hosted server keeps `submitFeedback`. Agents that previously called it should submit feedback via the hosted server or open a GitHub issue.
+
+### Changed
+
+- **Intent-first tool descriptions.** Every tool description was rewritten so agents pick the right tool from the description alone: each leads with what the tool returns and adds `Use when asked '...'` cues (e.g. `getNetworkPools` for "the biggest pools on Base", `getTokenPools` for "which pools hold WETH"). The `z.coerce.number()` parameter schemas and all output schemas are unchanged. Matches the descriptions now served by the hosted worker so hosted and self-host read identically.
+
 ## [2.2.1] - 2026-07-22
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dexpaprika-mcp",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dexpaprika-mcp",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexpaprika-mcp",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "A Model Context Protocol server for DexPaprika cryptocurrency data with network-specific pool queries",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Bumps `dexpaprika-mcp` to **2.3.0** so the already-merged changes actually reach self-host users.

**Why this is needed:** the published npm `2.2.1` (2026-07-22) predates the description work. Its tarball still ships the old tool descriptions and the `submitFeedback` stub. Merging the description PR updated `main` but did not publish, and npm won't accept a re-publish of `2.2.1`.

### Contents
- **Removed:** `submitFeedback` (self-host had a no-op stub; feedback lives on the hosted MCP). 16 read tools now.
- **Changed:** intent-first tool descriptions, matching the hosted worker. `z.coerce.number()` params and output schemas unchanged.

### Versioning note
Tagged **minor** (2.3.0) — the description rewrite is non-breaking; the `submitFeedback` removal is a tool-set change on a non-functional stub. If you'd rather signal the tool removal as breaking, bump to 3.0.0 before publishing.

### To release (maintainer, needs npm OTP)
```bash
git checkout main && git pull
npm publish            # enter OTP
git tag v2.3.0 && git push --tags
```

Refs coinpaprika/devrel#144.