### PR TITLE
Add server.json to refresh the MCP Registry entry (repo URL + version)

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "name": "com.dexpaprika/dexpaprika",
+  "title": "DexPaprika",
+  "description": "Real-time DEX and on-chain data: liquidity pools, token prices, swaps, and trading volume across blockchain networks.",
+  "repository": {
+    "url": "https://github.com/coinpaprika/dexpaprika-mcp",
+    "source": "github"
+  },
+  "version": "2.3.0",
+  "remotes": [
+    { "type": "streamable-http", "url": "https://mcp.dexpaprika.com/streamable-http" },
+    { "type": "sse", "url": "https://mcp.dexpaprika.com/sse" }
+  ]
+}


### PR DESCRIPTION
Adds `server.json` so the stale `com.dexpaprika/dexpaprika` registry entry can be refreshed via `mcp-publisher`.

**Why:** the live registry entry is out of date —
- `version: 1.1.0` (npm is now **2.3.0**)
- `repository:` **empty** — this is coinpaprika/devrel#113

### Manifest
Keeps the existing name + hosted remotes (`mcp.dexpaprika.com/streamable-http` + `/sse`), fills in the **repository** field, and bumps the version to 2.3.0.

### To publish (maintainer — DNS auth on **dexpaprika.com**, not coinpaprika.com)
```bash
# generate a key, add a TXT record at the dexpaprika.com apex:
#   dexpaprika.com. IN TXT "v=MCPv1; k=ed25519; p=<key>"
mcp-publisher login dns --domain dexpaprika.com --private-key <key>
mcp-publisher publish
```

Fixes coinpaprika/devrel#113. Part of coinpaprika/devrel#145.