### PR TITLE
README: add Smithery badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DexPaprika MCP Server
 
+[![smithery badge](https://smithery.ai/badge/coinpaprika/dexpaprika)](https://smithery.ai/servers/coinpaprika/dexpaprika)
+
 A Model Context Protocol (MCP) server that provides on-demand access to DexPaprika's cryptocurrency and DEX data API. Built specifically for AI assistants like Claude to programmatically fetch real-time token, pool, and DEX data with zero configuration.
 
 ## TL;DR


### PR DESCRIPTION
Adds the Smithery badge to the README, which satisfies the **Link to Smithery** verification check on our new Smithery listing (`coinpaprika/dexpaprika`). Smithery scans the README, homepage, or a custom backlink URL for a link back to the server page.

Verified: the badge URL returns 200 (image/svg+xml), and `SmitheryBot/1.0` is not blocked on our hosts, so the scan will see it.

https://claude.ai/code/session_01CjkiGV3q4pN7gUAR8vWRW7
