### PR TITLE
Support the 1h and 5m price-change windows in pool search

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const PACKAGE_VERSION = createRequire(import.meta.url)('../package.json').versio
 // Sort-field values accepted by the pool/token tools. Canonical *_24h names are
 // what /pools/search and /tokens/search use; the trailing short names are legacy
 // aliases kept for back-compat and normalized in search-mapping.js.
-const POOL_SORT_FIELDS = ['volume_usd_24h', 'volume_usd_7d', 'volume_usd_30d', 'liquidity_usd', 'txns_24h', 'created_at', 'price_usd', 'price_change_percentage_24h', 'volume_usd', 'transactions', 'last_price_change_usd_24h', 'volume_24h', 'volume_7d', 'volume_30d', 'liquidity'];
+const POOL_SORT_FIELDS = ['volume_usd_24h', 'volume_usd_7d', 'volume_usd_30d', 'liquidity_usd', 'txns_24h', 'created_at', 'price_usd', 'price_change_percentage_24h', 'price_change_percentage_6h', 'price_change_percentage_1h', 'price_change_percentage_5m', 'volume_usd', 'transactions', 'last_price_change_usd_24h', 'volume_24h', 'volume_7d', 'volume_30d', 'liquidity'];
 const TOKEN_SORT_FIELDS = ['volume_usd_24h', 'volume_usd_7d', 'volume_usd_30d', 'liquidity_usd', 'txns_24h', 'fdv_usd', 'created_at', 'price_change_percentage_24h', 'volume_24h', 'volume_7d', 'volume_30d', 'txns', 'price_change', 'fdv', 'price_usd'];
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -780,6 +780,17 @@ registerReadTool(
     liquidity_usd_min: z.coerce.number().optional().describe('OPTIONAL: Minimum pool liquidity in USD'),
     liquidity_usd_max: z.coerce.number().optional().describe('OPTIONAL: Maximum pool liquidity in USD'),
     txns_24h_min: z.coerce.number().optional().describe('OPTIONAL: Minimum number of transactions in 24h'),
+    // All four price-change windows filter. Verified live against a
+    // garbage-named control, so a silently-dropped parameter could not pass for
+    // a working one.
+    price_change_percentage_24h_min: z.coerce.number().optional().describe('OPTIONAL: Minimum 24h price change, in percent. Negatives are allowed, so -20 finds pools down at least 20%.'),
+    price_change_percentage_24h_max: z.coerce.number().optional().describe('OPTIONAL: Maximum 24h price change, in percent'),
+    price_change_percentage_6h_min: z.coerce.number().optional().describe('OPTIONAL: Minimum 6h price change, in percent'),
+    price_change_percentage_6h_max: z.coerce.number().optional().describe('OPTIONAL: Maximum 6h price change, in percent'),
+    price_change_percentage_1h_min: z.coerce.number().optional().describe('OPTIONAL: Minimum 1h price change, in percent'),
+    price_change_percentage_1h_max: z.coerce.number().optional().describe('OPTIONAL: Maximum 1h price change, in percent'),
+    price_change_percentage_5m_min: z.coerce.number().optional().describe("OPTIONAL: Minimum 5m price change, in percent. The shortest window we carry, so it is the one to reach for on 'what is moving right now'."),
+    price_change_percentage_5m_max: z.coerce.number().optional().describe('OPTIONAL: Maximum 5m price change, in percent'),
     created_after: z.coerce.number().optional().describe('OPTIONAL: Only pools created after this UNIX timestamp'),
     created_before: z.coerce.number().optional().describe('OPTIONAL: Only pools created before this UNIX timestamp'),
     sort_by: z.enum(POOL_SORT_FIELDS).optional().describe("OPTIONAL (preferred): Field to sort by (default: 'volume_usd_24h'). Prefer the canonical *_24h names; short legacy names are still accepted. The REST API calls this parameter order_by."),

--- a/src/search-mapping.js
+++ b/src/search-mapping.js
@@ -29,9 +29,14 @@
  * guaranteed by order).
  */
 
+// Must match the enum the REST layer returns in its 400 body. A field missing
+// here does not error: mapPoolSortField falls through to volume_usd_24h, so the
+// caller gets a successful response sorted by something they did not ask for.
 const POOL_SORT_CANONICAL = new Set([
   'volume_usd_24h', 'volume_usd_7d', 'volume_usd_30d', 'liquidity_usd',
-  'txns_24h', 'created_at', 'price_usd', 'price_change_percentage_24h',
+  'txns_24h', 'created_at', 'price_usd',
+  'price_change_percentage_24h', 'price_change_percentage_6h',
+  'price_change_percentage_1h', 'price_change_percentage_5m',
 ]);
 
 const POOL_SORT_LEGACY = {
@@ -81,6 +86,16 @@ const POOL_FILTER_PARAM = {
   liquidity_usd_min: 'liquidity_usd_min',
   liquidity_usd_max: 'liquidity_usd_max',
   txns_24h_min: 'txns_24h_min',
+  // Identity mappings, but they must be listed: this map is a whitelist, and a
+  // parameter missing from it is dropped before the request leaves.
+  price_change_percentage_24h_min: 'price_change_percentage_24h_min',
+  price_change_percentage_24h_max: 'price_change_percentage_24h_max',
+  price_change_percentage_6h_min: 'price_change_percentage_6h_min',
+  price_change_percentage_6h_max: 'price_change_percentage_6h_max',
+  price_change_percentage_1h_min: 'price_change_percentage_1h_min',
+  price_change_percentage_1h_max: 'price_change_percentage_1h_max',
+  price_change_percentage_5m_min: 'price_change_percentage_5m_min',
+  price_change_percentage_5m_max: 'price_change_percentage_5m_max',
   created_after: 'created_after',
   created_before: 'created_before',
 };


### PR DESCRIPTION
The REST API now accepts `price_change_percentage_1h` and `price_change_percentage_5m` as sort fields and as `_min`/`_max` filters on `/networks/{network}/pools/search`. The MCP could not reach either. The 6h window was live and equally missing, so it is in here too.

Three tables needed updating, and each one fails differently when a field is missing from it:

| Table | File | What a missing field does |
|---|---|---|
| `POOL_SORT_FIELDS` | `src/index.js` | Rejected at the tool boundary, before a request is built |
| `POOL_SORT_CANONICAL` | `src/search-mapping.js` | Remapped to `volume_usd_24h`: **200 OK, sorted by something else** |
| `POOL_FILTER_PARAM` | `src/search-mapping.js` | Whitelist, so the parameter is **dropped silently** |

The two silent modes are why this is worth fixing rather than leaving to callers: an agent asking for the biggest 5m movers got a plausible list of the biggest 24h movers instead, with nothing in the response to say so.

Also adds the eight filter parameters to the tool input schema, including the 24h pair, which the mapping already supported but the schema never exposed.

## Verification

Where the fallback happens is worth being precise about, because it changes what the evidence proves.

**Client side.** `mapPoolSortField` rewrites any field it does not recognise to `volume_usd_24h` before a request is built. Fed a garbage name it emits `?order_by=volume_usd_24h&sort=desc`. That is the fallback this PR stops the new windows from hitting.

**Server side.** The API itself does not fall back. An unknown `order_by` returns 400, and the body enumerates exactly what is allowed:

```
$ curl -s "https://api.dexpaprika.com/networks/ethereum/pools/search?order_by=zzz_not_a_field"
{"message":"invalid query parameters: order_by (must be one of [volume_usd_24h
volume_usd_7d volume_usd_30d liquidity_usd txns_24h created_at price_usd
price_change_percentage_24h price_change_percentage_6h price_change_percentage_1h
price_change_percentage_5m])"}
```

That list is the authority for this change, and the three names at the end are the gap.

Sorting, live, in both directions:

```
order_by=price_change_percentage_6h&sort=desc -> 2999701460315450, 1278252.46, 33613.16
order_by=price_change_percentage_6h&sort=asc  -> -97.45, -52.76, -45.83
order_by=price_change_percentage_1h&sort=desc -> 2640.80, 1198.66, 82.51
```

Filtering needs a stronger control than a status code, because unknown filter parameters do not 400. They are ignored, and the response is a full unfiltered result set with a 200 on it:

```
$ curl -s -o /dev/null -w "%{http_code}" ".../pools/search?zzz_not_a_param=5&limit=1"
200
```

So the proof is the contrast against a baseline:

```
price_change_percentage_1h_min=50  -> 91.46, 1000.14, 2640.80   (every value >= 50)
no filter at all (baseline)        -> 0, -0.00008, -0.087, -0.038, -0.045
```

A dropped bound would have returned the second list. It returned the first.

`npm test` and `npm run test:mcp` both pass.

## One thing this deliberately does not do

The same three windows are **not** added to any token path. `/networks/{network}/tokens/search` rejects them with a 400, and token rows carry no `price_change_percentage_5m` field at all. Its allowed list is its own:

```
volume_usd_24h volume_usd_7d volume_usd_30d price_usd liquidity_usd txns_24h
price_change_percentage_24h created_at fdv_usd
```

Note that it advertises `price_usd`, yet ordering tokens by `price_usd` still returns 400. The existing remap of token `price_usd` to `volume_usd_24h` is therefore still load-bearing and is untouched here.

https://claude.ai/code/session_016Zw5oLXk2fVxkVJvgqrc9j

---

## Correction, added after review

My first pass on this branch called the price-change windows pools-only across the board. That is right for the three short ones and wrong for 24h.

`/networks/{network}/tokens/search` honours `price_change_percentage_24h_min` and `_max`. A follow-up commit on this same branch adds them to the token side, with a test.

Measured on ethereum, and the misspelled control is what makes the rest of it evidence:

```
no filter                                 [95.7, -0.07, 0.23, -0.02, 0.4]
price_change_percentage_24h_min=20        [95.7, 36.62, 15876.53, 22.96, 32.88]
price_change_percentage_24h_max=-20       [-99.41, -22.53, -56.11, -86.58, -27.49]
price_change_pct_24h_min=20 (misspelled)  [95.7, -0.07, 0.23, -0.02, 0.4]
price_change_percentage_6h_min=20         [95.7, -0.07, 0.23, -0.02, 0.4]
```

The last line is the one that keeps the asymmetry honest: the 6h bound on tokens returns the unfiltered baseline, so the short windows really are pool-only. Sorting tokens by any of the three is a 400.

So the accurate statement is narrower than what I wrote first. The three short windows are pools-only. The 24h window works on both endpoints, for sorting and for filtering.
