### PR TITLE
Let token search filter on the 24h price change too

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1000,7 +1000,7 @@ registerReadTool(
 // ─── filterNetworkTokens ─────────────────────────────────────────────────────
 registerReadTool(
   'filterNetworkTokens',
-  'Get tokens on one network matching numeric thresholds, returned under \'results\' with has_next_page and next_cursor. Read-only and keyless. Choose this over getTopTokens when the user gives numeric constraints or a time window. Use for \'tokens with FDV over $10M on Base\', \'newly created tokens today\', or \'low-liquidity high-volume tokens\'. Optional filters (AND-combined): volume_24h_min/max, liquidity_usd_min/max, fdv_min/max, txns_24h_min, created_after/created_before (Unix timestamps). Also network (required); limit (default 50, max 100); cursor to page; sort_by (default \'volume_usd_24h\', alias order_by); sort_dir asc/desc (default \'desc\', alias sort).',
+  'Get tokens on one network matching numeric thresholds, returned under \'results\' with has_next_page and next_cursor. Read-only and keyless. Choose this over getTopTokens when the user gives numeric constraints or a time window. Use for \'tokens with FDV over $10M on Base\', \'newly created tokens today\', or \'low-liquidity high-volume tokens\'. Optional filters (AND-combined): volume_24h_min/max, liquidity_usd_min/max, fdv_min/max, txns_24h_min, price_change_percentage_24h_min/max, created_after/created_before (Unix timestamps). Also network (required); limit (default 50, max 100); cursor to page; sort_by (default \'volume_usd_24h\', alias order_by); sort_dir asc/desc (default \'desc\', alias sort).',
   {
     network: z.string().describe("REQUIRED: Network ID from getNetworks (e.g., 'ethereum', 'solana')"),
     limit: z.coerce.number().optional().default(50).describe('OPTIONAL: Number of items per page (default: 50, max: 100)'),
@@ -1012,6 +1012,8 @@ registerReadTool(
     fdv_min: z.coerce.number().optional().describe('OPTIONAL: Minimum fully diluted valuation in USD'),
     fdv_max: z.coerce.number().optional().describe('OPTIONAL: Maximum fully diluted valuation in USD'),
     txns_24h_min: z.coerce.number().optional().describe('OPTIONAL: Minimum number of transactions in 24h'),
+    price_change_percentage_24h_min: z.coerce.number().optional().describe('OPTIONAL: Minimum 24h price change, in percent. Negatives are allowed, so -20 finds tokens down at least 20%. This is the only price-change window tokens carry; for 6h, 1h or 5m use getNetworkPoolsFilter.'),
+    price_change_percentage_24h_max: z.coerce.number().optional().describe('OPTIONAL: Maximum 24h price change, in percent'),
     created_after: z.coerce.number().optional().describe('OPTIONAL: Only tokens created after this UNIX timestamp'),
     created_before: z.coerce.number().optional().describe('OPTIONAL: Only tokens created before this UNIX timestamp'),
     sort_by: z.enum(TOKEN_SORT_FIELDS).optional().describe("OPTIONAL (preferred): Field to sort by (default: 'volume_usd_24h'). Prefer the canonical names; short legacy names are still accepted. The REST API calls this parameter order_by."),

--- a/src/search-mapping.js
+++ b/src/search-mapping.js
@@ -108,6 +108,11 @@ const TOKEN_FILTER_PARAM = {
   fdv_min: 'fdv_min',
   fdv_max: 'fdv_max',
   txns_24h_min: 'txns_24h_min',
+  // The 24h window is the only price-change bound tokens/search honours. The
+  // shorter ones are absent from token rows and are ignored if sent, so they
+  // are deliberately not listed here.
+  price_change_percentage_24h_min: 'price_change_percentage_24h_min',
+  price_change_percentage_24h_max: 'price_change_percentage_24h_max',
   created_after: 'created_after',
   created_before: 'created_before',
 };


### PR DESCRIPTION
Follow-up to the price-change window PR that just merged. That one framed all four windows as pools-only. Right for the three short ones, wrong for 24h, and this closes the gap it left on the token side.

`/networks/{network}/tokens/search` honours `price_change_percentage_24h_min` and `_max`. Neither could be sent before this.

## Why it needed proving rather than trying

An unrecognised filter parameter does not fail. The endpoint answers `200` and returns the full unfiltered page, so "I sent it and got results" is not evidence of anything. The proof is the contrast, on ethereum:

```
no filter                                 [95.7, -0.07, 0.23, -0.02, 0.4]
price_change_percentage_24h_min=20        [95.7, 36.62, 15876.53, 22.96, 32.88]
price_change_percentage_24h_max=-20       [-99.41, -22.53, -56.11, -86.58, -27.49]
price_change_pct_24h_min=20 (misspelled)  [95.7, -0.07, 0.23, -0.02, 0.4]
price_change_percentage_6h_min=20         [95.7, -0.07, 0.23, -0.02, 0.4]
```

Line four is the control: a misspelled name returns the baseline row for row, which is what makes lines two and three mean something. Line five is why the short windows stay off the token side. Token rows carry no 6h, 1h or 5m field, so the bound is dropped, and ordering by any of the three is a `400`.

## Consistency

Every other surface in this rollout now carries the token 24h bounds: the Go, TypeScript, Python and PHP SDKs, the hosted MCP worker, and the CLI's `filter-tokens`.

https://claude.ai/code/session_016Zw5oLXk2fVxkVJvgqrc9j
