### PR TITLE
feat: optional API key, client identification, and honest rate-limit errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,8 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Unit and wire tests
+        run: npm run test:unit
+
       - name: MCP smoke (initialize + tools/list)
         run: node .github/smoke.mjs

--- a/README.md
+++ b/README.md
@@ -81,6 +81,46 @@ Add the following to your Claude Desktop configuration file:
 
 After restarting Claude Desktop, the DexPaprika tools will be available to Claude automatically.
 
+### Optional: using an API key
+
+**This works without a key and always will.** No signup, no card, nothing to
+configure. Everything above is the supported way to run it.
+
+A free key raises the monthly allowance and opens streaming on any token rather
+than the public showcase set. It does **not** raise the per-minute request
+limit, which is the same on both tiers. Get one at
+[console.dexpaprika.com](https://console.dexpaprika.com); current limits are on
+the [rate limits page](https://docs.dexpaprika.com/knowledge-base/rate-limits).
+
+```json
+{
+  "mcpServers": {
+    "dexpaprika": {
+      "command": "npx",
+      "args": ["dexpaprika-mcp@latest"],
+      "env": {
+        "DEXPAPRIKA_API_KEY": "your_key_here"
+      }
+    }
+  }
+}
+```
+
+**The key goes in on its own. There is no `Bearer` prefix**, and no other scheme
+word either. Paste the key exactly as issued. Almost every other API wants the
+opposite, so this is the single most common reason a working key looks broken.
+
+Two things worth knowing:
+
+- **A key we cannot read does not produce an error.** The data endpoints ignore
+  an unreadable key and serve you as an anonymous caller, with a normal `200` and
+  real data, so a typo looks exactly like success. Ask the assistant to run
+  `getKeyStatus` after setting one: it reports which plan the API actually sees
+  and names the likely cause when the key is not landing.
+- **Pro customers** additionally set `DEXPAPRIKA_API_BASE_URL` to
+  `https://api-pro.dexpaprika.com`. The host does not change automatically,
+  because sending a free key to that host returns 403.
+
 ### Hosted server (no installation)
 
 If you prefer zero setup, point any MCP-compatible client directly at the hosted server at [mcp.dexpaprika.com](https://mcp.dexpaprika.com). The landing page provides setup instructions and documentation. The following transport endpoints are available:
@@ -104,9 +144,9 @@ If you prefer zero setup, point any MCP-compatible client directly at the hosted
 }
 ```
 
-## Available Tools (16)
+## Available Tools (17)
 
-This self-host build registers 16 read tools. The hosted server at `mcp.dexpaprika.com` registers 17: the same 16 plus `submitFeedback`. Verify either with a live `tools/list`.
+This self-host build registers 17 read tools: 16 market-data tools plus `getKeyStatus`. The hosted server at `mcp.dexpaprika.com` registers its own set including `submitFeedback`. Verify either with a live `tools/list`.
 
 ### Discovery
 
@@ -116,6 +156,7 @@ This self-host build registers 16 read tools. The hosted server at `mcp.dexpapri
 | `getNetworks` | List every supported blockchain network (36) |
 | `getStats` | High-level ecosystem stats (total networks, DEXes, pools, tokens) |
 | `search` | Search tokens, pools, and DEXes across ALL networks by name, symbol, or address |
+| `getKeyStatus` | Whether a key is being sent and which plan the API sees. Reads no market data. |
 
 ### DEX Operations
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "watch": "nodemon --watch src --exec npm start",
     "test": "node src/test.js",
     "test:api": "node src/test_methods.js",
-    "test:mcp": "node src/test_mcp_client.js"
+    "test:mcp": "node src/test_mcp_client.js",
+    "test:unit": "node --test test/*.test.js"
   },
   "keywords": [
     "mcp",

--- a/src/http-config.js
+++ b/src/http-config.js
@@ -1,0 +1,143 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Outbound request configuration: base URL, optional API key, client identity.
+//
+// Keyless is and stays the default. With no key configured, the only difference
+// from what this package sent before is a User-Agent, which is what lets us tell
+// this tool's traffic apart from everything else hitting the API.
+//
+// Pure module on purpose: every rule below is unit-tested in
+// test/http-config.test.js without starting a server or touching the network.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Anything that could break out of a header value. A key or client name
+ * carrying CR, LF or NUL is not sanitised into something usable, it is dropped:
+ * a silently mangled key would authenticate as nobody and, because our data
+ * endpoints ignore an unreadable key rather than rejecting it, the caller would
+ * never find out.
+ */
+const HEADER_UNSAFE = /[\r\n\0]/;
+
+/** Client names arrive from the MCP handshake, so they are untrusted input. */
+const CLIENT_TOKEN_UNSAFE = /[^\w.@/-]+/g;
+const CLIENT_FIELD_MAX = 48;
+
+/**
+ * Read a usable API key off an env-shaped object, or null for keyless.
+ *
+ * @param {Record<string, unknown>} [env]
+ * @returns {string|null}
+ */
+export function resolveApiKey(env = process.env) {
+  const raw = env?.DEXPAPRIKA_API_KEY;
+  if (typeof raw !== 'string') return null;
+  const key = raw.trim();
+  if (key === '') return null;
+  if (HEADER_UNSAFE.test(key)) return null;
+  return key;
+}
+
+/** Reduce an untrusted client-supplied string to something safe in a header. */
+function sanitizeClientField(value) {
+  if (typeof value !== 'string') return '';
+  return value.replace(CLIENT_TOKEN_UNSAFE, '_').slice(0, CLIENT_FIELD_MAX);
+}
+
+/**
+ * `dexpaprika-mcp/2.4.1 (node/22.1.0; darwin; client=claude-desktop/1.2.3)`
+ *
+ * The client segment comes from the MCP initialize handshake and is omitted
+ * entirely when we do not have it, rather than guessed.
+ */
+export function buildUserAgent({ version, client, runtime } = {}) {
+  const nodeVersion = runtime?.node ?? process.versions.node;
+  const platform = runtime?.platform ?? process.platform;
+
+  const parts = [`node/${nodeVersion}`, platform];
+
+  const name = sanitizeClientField(client?.name);
+  if (name !== '') {
+    const clientVersion = sanitizeClientField(client?.version);
+    parts.push(clientVersion === '' ? `client=${name}` : `client=${name}/${clientVersion}`);
+  }
+
+  return `dexpaprika-mcp/${version ?? '0.0.0'} (${parts.join('; ')})`;
+}
+
+/**
+ * Headers for an outbound API call.
+ *
+ * **The key is the entire `Authorization` value.** There is no `Bearer` prefix
+ * and no other scheme word. `Authorization: Bearer api_...` returns 401, because
+ * the API checksums the raw header value and nothing strips a scheme word off
+ * the front. This is the single most common reason a working key looks broken,
+ * it has resurfaced three times in four months, and the test file pins the
+ * format precisely so nobody reintroduces it.
+ *
+ * @returns {Record<string, string>}
+ */
+export function buildHeaders({ version, client, runtime, env } = {}) {
+  const headers = { 'User-Agent': buildUserAgent({ version, client, runtime }) };
+
+  const key = resolveApiKey(env);
+  if (key !== null) headers.Authorization = key;
+
+  return headers;
+}
+
+/**
+ * Seconds from an inbound `Retry-After`, or null when it is absent or unusable.
+ *
+ * RFC 9110 allows either delta-seconds or an HTTP-date, so both are handled.
+ * Null means "we do not know" and callers must say so: inventing a number is
+ * exactly how this package came to advise waiting until local midnight for a
+ * limit that clears in seconds.
+ *
+ * @param {{ get?: (name: string) => string|null }} [responseHeaders]
+ * @param {number} [now] epoch ms, injectable so the date branch is testable
+ * @returns {number|null}
+ */
+export function parseRetryAfterSeconds(responseHeaders, now = Date.now()) {
+  const raw = responseHeaders?.get?.('retry-after');
+  if (typeof raw !== 'string' || raw.trim() === '') return null;
+
+  const asSeconds = Number(raw.trim());
+  if (Number.isFinite(asSeconds)) return asSeconds < 0 ? 0 : Math.ceil(asSeconds);
+
+  const asDate = Date.parse(raw);
+  if (Number.isNaN(asDate)) return null;
+  return Math.max(0, Math.ceil((asDate - now) / 1000));
+}
+
+/** Default origin. Serves keyless callers and registered free keys alike. */
+export const DEFAULT_BASE_URL = 'https://api.dexpaprika.com';
+
+/**
+ * Resolve the API origin.
+ *
+ * The host does **not** change when a key is present. Keyless callers and
+ * registered free keys are both served from the default origin, and only Pro
+ * moves to `api-pro.dexpaprika.com`, so Pro customers set this explicitly.
+ * Sending a free key to an api-pro host returns 403 rather than 401, which is
+ * why guessing the host from the key would be worse than making it explicit.
+ *
+ * An unusable value falls back to the default rather than throwing: a data tool
+ * that refuses to start over a typo in an optional variable is a worse outcome
+ * than one that keeps working against the public API.
+ *
+ * @returns {string} origin with no trailing slash
+ */
+export function resolveBaseUrl(env = process.env) {
+  const raw = env?.DEXPAPRIKA_API_BASE_URL;
+  if (typeof raw !== 'string' || raw.trim() === '') return DEFAULT_BASE_URL;
+
+  let parsed;
+  try {
+    parsed = new URL(raw.trim());
+  } catch {
+    return DEFAULT_BASE_URL;
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return DEFAULT_BASE_URL;
+
+  return `${parsed.origin}${parsed.pathname}`.replace(/\/+$/, '');
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 import { createRequire } from 'module';
 import { buildPoolSearchParams, buildTokenSearchParams, toQueryString } from './search-mapping.js';
+import { buildHeaders, parseRetryAfterSeconds, resolveApiKey, resolveBaseUrl } from './http-config.js';
 
 const PACKAGE_VERSION = createRequire(import.meta.url)('../package.json').version;
 
@@ -19,11 +20,36 @@ const TOKEN_SORT_FIELDS = ['volume_usd_24h', 'volume_usd_7d', 'volume_usd_30d', 
 // instructions and version match the worker.
 // ─────────────────────────────────────────────────────────────────────────────
 
-// Base URL for DexPaprika API. DexPaprika is fully free: no API key, no auth header.
-const API_BASE_URL = 'https://api.dexpaprika.com';
+// Base URL for DexPaprika API.
+//
+// Keyless works and stays the default: no key, no signup, nothing to configure.
+// Setting DEXPAPRIKA_API_KEY raises the monthly allowance and opens streaming on
+// any token. The host does NOT change when a key is present: free keys are served
+// here, and only Pro moves to api-pro.dexpaprika.com.
+const API_BASE_URL = resolveBaseUrl();
 
 // Server version — matches the hosted worker.
 const SERVER_VERSION = '2.0.0';
+
+// Which MCP client we are talking to, learned from the initialize handshake and
+// forwarded in the User-Agent. Stays null until the handshake completes, and the
+// User-Agent simply omits the segment while it is unknown rather than guessing.
+let mcpClient = null;
+
+function currentHeaders() {
+  // getClientVersion() returns undefined until the initialize handshake lands,
+  // so this resolves on first use rather than at startup. Guarded because it is
+  // reaching through the SDK's public-but-nested surface for a nice-to-have.
+  if (mcpClient === null) {
+    try {
+      const info = server?.server?.getClientVersion?.();
+      if (info?.name) mcpClient = { name: info.name, version: info.version };
+    } catch {
+      // Identification is optional. Never let it break a data call.
+    }
+  }
+  return buildHeaders({ version: PACKAGE_VERSION, client: mcpClient });
+}
 
 // Server identity (inlined from the worker's server-identity.ts).
 const SERVER_CANONICAL_NAME = 'dexpaprika';
@@ -121,6 +147,7 @@ const ErrorCodes = {
   DP400_UNSUPPORTED_PARAM: 'DP400_UNSUPPORTED_PARAM',
   DP404_NOT_FOUND: 'DP404_NOT_FOUND',
   DP429_RATE_LIMIT: 'DP429_RATE_LIMIT',
+  DP402_QUOTA_EXHAUSTED: 'DP402_QUOTA_EXHAUSTED',
 };
 
 function buildErrorResponse(code, message, retryable, suggestion, correctedExample, metadata) {
@@ -152,7 +179,7 @@ function parseDeprecationHint(body) {
   return { replacement, apiMessage };
 }
 
-function parseAPIError(status, statusText, endpoint, body) {
+function parseAPIError(status, statusText, endpoint, body, responseHeaders) {
   // Generic, self-documenting deprecation handling: if the error body carries a
   // "replacement" hint, surface BOTH the API message and the replacement path,
   // for ANY error status. Keeps the DP<status>_ERROR code structure.
@@ -199,17 +226,48 @@ function parseAPIError(status, statusText, endpoint, body) {
   }
 
   if (status === 429) {
-    const resetTime = new Date();
-    resetTime.setHours(24, 0, 0, 0);
+    // This is the PER-MINUTE request limit, not the monthly credit allowance.
+    // Until 2026-08-14 this branch reported a "daily" limit and told the caller
+    // to wait until local midnight, which for an agent meant giving up for hours
+    // on a limit that clears in seconds. Honour the server's own Retry-After.
+    const retryAfterSeconds = parseRetryAfterSeconds(responseHeaders);
     return buildErrorResponse(
       ErrorCodes.DP429_RATE_LIMIT,
-      'Daily rate limit exceeded',
+      'Per-minute request limit exceeded',
       true,
-      'Wait until rate limit resets or use cached data',
+      retryAfterSeconds === null
+        ? 'Wait a few seconds and retry. This is a per-minute limit, so it clears on its own; it is not the monthly credit allowance running out.'
+        : `Wait ${retryAfterSeconds}s and retry, then pace requests below the limit. This is a per-minute limit, not the monthly credit allowance.`,
+      'getTokenMultiPrices({ network, tokens: [a, b, c] })  // up to 10 per request',
+      {
+        limit_type: 'requests_per_minute',
+        // Null rather than invented: a made-up number is what produced the
+        // wait-until-midnight advice this replaces.
+        retry_after_seconds: retryAfterSeconds,
+        // Deliberately no "register for more" hint here. A free API key raises
+        // the monthly allowance and opens streaming, but it does NOT raise the
+        // per-minute limit, so suggesting it at this moment would be false.
+        reduce_request_count: 'Batch up to 10 tokens per call with getTokenMultiPrices, or stream instead of polling.',
+      },
+    );
+  }
+
+  if (status === 402) {
+    // Monthly credit allowance exhausted. Unlike 429, a free key genuinely does
+    // help here: it raises the ceiling from the keyless allowance.
+    const keyed = resolveApiKey() !== null;
+    return buildErrorResponse(
+      ErrorCodes.DP402_QUOTA_EXHAUSTED,
+      'Monthly credit allowance exhausted',
+      false,
+      keyed
+        ? 'This key has spent its monthly credits. The allowance resets at the start of the next period, and the response body carries the current upgrade options.'
+        : 'Running keyless. A free API key raises the monthly allowance well above the keyless tier and takes no card: set DEXPAPRIKA_API_KEY and restart. Current limits: https://docs.dexpaprika.com/knowledge-base/rate-limits',
       undefined,
       {
-        reset_at: resetTime.toISOString(),
-        retry_after_seconds: Math.floor((resetTime.getTime() - Date.now()) / 1000),
+        limit_type: 'monthly_credits',
+        using_api_key: keyed,
+        endpoint,
       },
     );
   }
@@ -245,7 +303,7 @@ async function fetchFromAPI(endpoint) {
   // canonical network IDs. No-op for already-canonical IDs and non-/networks paths.
   endpoint = normalizeNetworkPath(endpoint);
   const url = `${API_BASE_URL}${endpoint}`;
-  const response = await fetch(url);
+  const response = await fetch(url, { headers: currentHeaders() });
   if (!response.ok) {
     // Read the error body so a deprecation hint (a "replacement" field) can be
     // surfaced to the caller. Defensive: the body may be empty or non-JSON, in
@@ -258,7 +316,7 @@ async function fetchFromAPI(endpoint) {
     }
     console.error(`[upstream] url=${url} http_status=${response.status} text="${response.statusText}"`);
     // Preserve the package's structured error contract.
-    throw parseAPIError(response.status, response.statusText, endpoint, body);
+    throw parseAPIError(response.status, response.statusText, endpoint, body, response.headers);
   }
   return response.json();
 }
@@ -628,6 +686,55 @@ const server = new McpServer(
   },
   {
     instructions: SERVER_INSTRUCTIONS,
+  },
+);
+
+// ─── getKeyStatus ────────────────────────────────────────────────────────────
+// Answers "is my key actually being used?", which on this API you cannot tell
+// from a normal call: the data endpoints ignore an unreadable key and serve the
+// keyless tier with a 200, so a wrong header name looks exactly like success.
+// /usage is the one endpoint that reports the truth.
+server.registerTool(
+  'getKeyStatus',
+  {
+    description:
+      'Report whether this server is sending an API key and which plan the API sees. '
+      + 'Use when calls are being rate limited or refused, or when the user asks whether '
+      + 'their DexPaprika key is working. Takes no arguments and reads no market data.',
+    inputSchema: {},
+    annotations: ANNOTATIONS_READ_ONLY,
+  },
+  async () => {
+    const configured = resolveApiKey() !== null;
+    try {
+      const usage = await fetchFromAPI('/usage');
+      const plan = typeof usage?.plan === 'string' ? usage.plan : null;
+      return jsonText({
+        api_key_configured: configured,
+        key_source: configured ? 'DEXPAPRIKA_API_KEY environment variable' : null,
+        plan_reported_by_api: plan,
+        // The one case worth calling out loudly: a key is set but the API still
+        // sees an anonymous caller, so the key is not reaching us at all.
+        key_reaching_api: configured ? plan !== null && plan !== 'keyless' : false,
+        diagnosis: !configured
+          ? 'No key configured. Running keyless, which works and needs no signup. Set DEXPAPRIKA_API_KEY to raise the monthly allowance and open streaming on any token.'
+          : plan === 'keyless'
+            ? 'A key is configured but the API still reports the keyless plan, so it is not reaching us. Check the variable name is exactly DEXPAPRIKA_API_KEY and that the value is the key on its own.'
+            : `Key is working. The API reports plan "${plan}".`,
+        usage,
+      });
+    } catch (error) {
+      // A 401 here is itself the answer: the key arrived and was rejected.
+      return jsonText({
+        api_key_configured: configured,
+        plan_reported_by_api: null,
+        key_reaching_api: false,
+        diagnosis: configured
+          ? 'The key reached the API and was rejected. The most common cause by far is a scheme word: the key must be the entire Authorization value, with no "Bearer" in front. Otherwise check for a truncated paste.'
+          : 'Could not read usage. The server is running keyless, which is the default and needs no key.',
+        error: error && typeof error === 'object' && 'error' in error ? error.error : String(error),
+      });
+    }
   },
 );
 

--- a/test/http-config.test.js
+++ b/test/http-config.test.js
@@ -1,0 +1,149 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildHeaders, buildUserAgent, resolveApiKey, resolveBaseUrl, DEFAULT_BASE_URL } from '../src/http-config.js';
+
+const RUNTIME = { node: '22.0.0', platform: 'linux' };
+const base = (env) => buildHeaders({ version: '2.4.1', runtime: RUNTIME, env });
+
+// ── The Bearer rule ─────────────────────────────────────────────────────────
+// This is the regression this whole file exists for. `Authorization: Bearer
+// api_...` returns 401 because the API checksums the raw header value. It has
+// resurfaced three times in four months, so pin it exactly rather than loosely.
+
+test('the key is the entire Authorization value, with no scheme word', () => {
+  const headers = base({ DEXPAPRIKA_API_KEY: 'api_abc123' });
+  assert.equal(headers.Authorization, 'api_abc123');
+});
+
+test('Authorization never gains a Bearer prefix', () => {
+  const headers = base({ DEXPAPRIKA_API_KEY: 'api_abc123' });
+  assert.doesNotMatch(headers.Authorization, /^\s*Bearer\b/i);
+});
+
+test('no scheme word of any kind is prepended', () => {
+  const headers = base({ DEXPAPRIKA_API_KEY: 'api_abc123' });
+  for (const scheme of ['Bearer', 'Token', 'ApiKey', 'Basic', 'Key']) {
+    assert.doesNotMatch(headers.Authorization, new RegExp(`^\\s*${scheme}\\b`, 'i'));
+  }
+});
+
+// ── Keyless stays the default ───────────────────────────────────────────────
+
+test('no key configured sends no Authorization header at all', () => {
+  assert.equal('Authorization' in base({}), false);
+});
+
+test('an empty or whitespace-only key is keyless, not an empty header', () => {
+  for (const value of ['', '   ', '\t']) {
+    assert.equal('Authorization' in base({ DEXPAPRIKA_API_KEY: value }), false);
+  }
+});
+
+test('a non-string key is ignored rather than coerced', () => {
+  for (const value of [null, undefined, 42, {}, []]) {
+    assert.equal(resolveApiKey({ DEXPAPRIKA_API_KEY: value }), null);
+  }
+});
+
+test('surrounding whitespace is trimmed off a real key', () => {
+  assert.equal(resolveApiKey({ DEXPAPRIKA_API_KEY: '  api_abc123\n' }), 'api_abc123');
+});
+
+// ── Header injection ────────────────────────────────────────────────────────
+
+test('a key containing CR or LF is dropped, not sanitised into a broken key', () => {
+  for (const value of ['api_a\r\nX-Evil: 1', 'api_a\nb', 'api_a\0b']) {
+    assert.equal(resolveApiKey({ DEXPAPRIKA_API_KEY: value }), null,
+      `expected ${JSON.stringify(value)} to be rejected`);
+  }
+});
+
+test('a hostile client name cannot inject a header', () => {
+  const ua = buildUserAgent({
+    version: '2.4.1', runtime: RUNTIME,
+    client: { name: 'evil\r\nX-Injected: 1', version: '1.0' },
+  });
+  assert.doesNotMatch(ua, /[\r\n]/);
+});
+
+test('client fields are length-capped', () => {
+  const ua = buildUserAgent({
+    version: '2.4.1', runtime: RUNTIME,
+    client: { name: 'a'.repeat(500), version: 'b'.repeat(500) },
+  });
+  assert.ok(ua.length < 200, `user agent was ${ua.length} chars`);
+});
+
+// ── User-Agent shape ────────────────────────────────────────────────────────
+
+test('user agent identifies the package, its version and the runtime', () => {
+  const ua = buildUserAgent({ version: '2.4.1', runtime: RUNTIME });
+  assert.equal(ua, 'dexpaprika-mcp/2.4.1 (node/22.0.0; linux)');
+});
+
+test('a known MCP client is named in the user agent', () => {
+  const ua = buildUserAgent({
+    version: '2.4.1', runtime: RUNTIME,
+    client: { name: 'claude-desktop', version: '1.2.3' },
+  });
+  assert.equal(ua, 'dexpaprika-mcp/2.4.1 (node/22.0.0; linux; client=claude-desktop/1.2.3)');
+});
+
+test('a client with no version still gets named', () => {
+  const ua = buildUserAgent({
+    version: '2.4.1', runtime: RUNTIME, client: { name: 'cursor' },
+  });
+  assert.match(ua, /client=cursor\)$/);
+});
+
+test('an unknown client is omitted rather than guessed', () => {
+  for (const client of [undefined, {}, { name: '' }, { name: null }]) {
+    const ua = buildUserAgent({ version: '2.4.1', runtime: RUNTIME, client });
+    assert.doesNotMatch(ua, /client=/);
+  }
+});
+
+test('a user agent is always sent, key or no key', () => {
+  assert.match(base({})['User-Agent'], /^dexpaprika-mcp\//);
+  assert.match(base({ DEXPAPRIKA_API_KEY: 'api_x' })['User-Agent'], /^dexpaprika-mcp\//);
+});
+
+// ── Base URL ────────────────────────────────────────────────────────────────
+// The host must never be inferred from the presence of a key. Free keys are
+// served on the default origin and only Pro moves to api-pro, so a wrong guess
+// would return 403 to exactly the people who just registered.
+
+test('the default origin is used when nothing is configured', () => {
+  for (const env of [{}, { DEXPAPRIKA_API_BASE_URL: '' }, { DEXPAPRIKA_API_BASE_URL: '  ' }]) {
+    assert.equal(resolveBaseUrl(env), DEFAULT_BASE_URL);
+  }
+});
+
+test('a key alone never changes the host', () => {
+  assert.equal(resolveBaseUrl({ DEXPAPRIKA_API_KEY: 'api_abc123' }), DEFAULT_BASE_URL);
+});
+
+test('Pro customers can point at api-pro explicitly', () => {
+  assert.equal(
+    resolveBaseUrl({ DEXPAPRIKA_API_BASE_URL: 'https://api-pro.dexpaprika.com' }),
+    'https://api-pro.dexpaprika.com',
+  );
+});
+
+test('a trailing slash does not produce a double slash in request paths', () => {
+  assert.equal(
+    resolveBaseUrl({ DEXPAPRIKA_API_BASE_URL: 'https://api-pro.dexpaprika.com/' }),
+    'https://api-pro.dexpaprika.com',
+  );
+});
+
+test('an unusable value falls back rather than breaking the tool', () => {
+  for (const value of ['not a url', 'ftp://example.com', 'file:///etc/passwd', '://x']) {
+    assert.equal(resolveBaseUrl({ DEXPAPRIKA_API_BASE_URL: value }), DEFAULT_BASE_URL,
+      `expected ${value} to fall back`);
+  }
+});
+
+test('a local origin is accepted, which is what the wire tests run against', () => {
+  assert.equal(resolveBaseUrl({ DEXPAPRIKA_API_BASE_URL: 'http://127.0.0.1:8080' }), 'http://127.0.0.1:8080');
+});

--- a/test/retry-after.test.js
+++ b/test/retry-after.test.js
@@ -1,0 +1,62 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseRetryAfterSeconds } from '../src/http-config.js';
+
+/** Minimal stand-in for the Headers interface fetch hands back. */
+const headers = (value) => ({ get: (name) => (name === 'retry-after' ? value : null) });
+
+const NOW = Date.parse('2026-08-14T12:00:00Z');
+
+test('reads delta-seconds, the form our API sends', () => {
+  assert.equal(parseRetryAfterSeconds(headers('20')), 20);
+});
+
+test('surrounding whitespace does not defeat it', () => {
+  assert.equal(parseRetryAfterSeconds(headers('  20  ')), 20);
+});
+
+test('a fractional value rounds up rather than truncating into a busy retry', () => {
+  assert.equal(parseRetryAfterSeconds(headers('1.2')), 2);
+});
+
+test('a negative value clamps to zero rather than scheduling a retry in the past', () => {
+  assert.equal(parseRetryAfterSeconds(headers('-5')), 0);
+});
+
+test('an HTTP-date is converted against the supplied clock', () => {
+  assert.equal(parseRetryAfterSeconds(headers('Fri, 14 Aug 2026 12:00:30 GMT'), NOW), 30);
+});
+
+test('an HTTP-date already in the past clamps to zero', () => {
+  assert.equal(parseRetryAfterSeconds(headers('Fri, 14 Aug 2026 11:59:00 GMT'), NOW), 0);
+});
+
+// Null means "we do not know". The caller must say so rather than substitute a
+// guess: a guessed value is what produced the wait-until-midnight advice that
+// this replaced, which told agents to give up for hours on a per-minute limit.
+test('a missing header is null, not a guess', () => {
+  assert.equal(parseRetryAfterSeconds(headers(null)), null);
+});
+
+test('an empty header is null', () => {
+  assert.equal(parseRetryAfterSeconds(headers('   ')), null);
+});
+
+test('an unparseable header is null', () => {
+  assert.equal(parseRetryAfterSeconds(headers('soon')), null);
+});
+
+test('a response with no headers object at all does not throw', () => {
+  for (const value of [undefined, null, {}]) {
+    assert.equal(parseRetryAfterSeconds(value), null);
+  }
+});
+
+test('never returns the multi-hour value the old midnight logic produced', () => {
+  // Regression guard. The previous implementation ignored the header entirely
+  // and computed seconds-until-local-midnight, which could exceed 80,000.
+  for (const raw of ['20', '1', '0', 'Fri, 14 Aug 2026 12:00:30 GMT']) {
+    const seconds = parseRetryAfterSeconds(headers(raw), NOW);
+    assert.ok(seconds !== null && seconds < 3600, `${raw} gave ${seconds}`);
+  }
+});

--- a/test/wire.test.js
+++ b/test/wire.test.js
@@ -1,0 +1,155 @@
+// End-to-end over the real MCP transport: spawn the built server exactly as a
+// user's client would, and assert on what reaches the wire. The unit tests pin
+// the header rules; this pins that the rules are actually applied to a request.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+
+/** A throwaway origin that records the requests our server makes to it. */
+async function recordingUpstream(handler) {
+  const seen = [];
+  const server = createServer((req, res) => {
+    seen.push({ url: req.url, headers: req.headers });
+    handler(req, res, seen.length);
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  return { seen, port: server.address().port, close: () => server.close() };
+}
+
+/** Drive the MCP server over stdio and return the response to one tool call. */
+async function callTool({ env, toolName, args = {} }) {
+  const child = spawn(process.execPath, ['dist/bin.js'], {
+    env: { ...process.env, ...env },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  let out = '';
+  child.stdout.on('data', (c) => { out += c; });
+  child.stderr.on('data', () => {});
+
+  const send = (msg) => child.stdin.write(`${JSON.stringify(msg)}\n`);
+
+  send({
+    jsonrpc: '2.0', id: 1, method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05', capabilities: {},
+      clientInfo: { name: 'wire-test-client', version: '9.9.9' },
+    },
+  });
+  send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+  send({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: toolName, arguments: args } });
+
+  const deadline = Date.now() + 15000;
+  while (Date.now() < deadline) {
+    if (out.split('\n').some((l) => l.trim().startsWith('{') && JSON.parse(l).id === 2)) break;
+    await new Promise((r) => setTimeout(r, 40));
+  }
+  child.kill();
+
+  const line = out.split('\n').find((l) => {
+    try { return JSON.parse(l).id === 2; } catch { return false; }
+  });
+  assert.ok(line, `no response to the tool call. stdout was:\n${out}`);
+  return JSON.parse(line);
+}
+
+const RATIONALE = 'Automated wire test asserting which headers the server attaches to outbound calls.';
+
+/** Unwrap the MCP result envelope into the payload object the tool returned. */
+function payload(response) {
+  const text = response?.result?.content?.[0]?.text;
+  assert.ok(typeof text === 'string', `no text content in ${JSON.stringify(response)}`);
+  return JSON.parse(text);
+}
+
+test('keyless sends no Authorization header but does identify itself', async () => {
+  const upstream = await recordingUpstream((req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end('[]');
+  });
+  try {
+    await callTool({
+      env: { DEXPAPRIKA_API_BASE_URL: `http://127.0.0.1:${upstream.port}`, DEXPAPRIKA_API_KEY: '' },
+      toolName: 'getNetworks', args: { rationale: RATIONALE },
+    });
+    assert.ok(upstream.seen.length > 0, 'the server never called upstream');
+    const { headers } = upstream.seen[0];
+    assert.equal(headers.authorization, undefined);
+    assert.match(headers['user-agent'], /^dexpaprika-mcp\//);
+  } finally { upstream.close(); }
+});
+
+test('a configured key reaches the wire bare, with no Bearer prefix', async () => {
+  const upstream = await recordingUpstream((req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end('[]');
+  });
+  try {
+    await callTool({
+      env: { DEXPAPRIKA_API_BASE_URL: `http://127.0.0.1:${upstream.port}`, DEXPAPRIKA_API_KEY: 'api_wire_test_key' },
+      toolName: 'getNetworks', args: { rationale: RATIONALE },
+    });
+    const { headers } = upstream.seen[0];
+    assert.equal(headers.authorization, 'api_wire_test_key');
+    assert.doesNotMatch(headers.authorization, /bearer/i);
+  } finally { upstream.close(); }
+});
+
+test('the MCP client from the handshake is carried in the user agent', async () => {
+  const upstream = await recordingUpstream((req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end('[]');
+  });
+  try {
+    await callTool({
+      env: { DEXPAPRIKA_API_BASE_URL: `http://127.0.0.1:${upstream.port}` },
+      toolName: 'getNetworks', args: { rationale: RATIONALE },
+    });
+    assert.match(upstream.seen[0].headers['user-agent'], /client=wire-test-client\/9\.9\.9/);
+  } finally { upstream.close(); }
+});
+
+test('a 429 reports the per-minute limit and the server-supplied Retry-After', async () => {
+  const upstream = await recordingUpstream((req, res) => {
+    res.writeHead(429, { 'content-type': 'application/json', 'retry-after': '20' });
+    res.end('{"message":"rate limit"}');
+  });
+  try {
+    const response = await callTool({
+      env: { DEXPAPRIKA_API_BASE_URL: `http://127.0.0.1:${upstream.port}` },
+      toolName: 'getNetworks', args: { rationale: RATIONALE },
+    });
+    const { error } = payload(response);
+    assert.equal(error.code, 'DP429_RATE_LIMIT');
+    assert.equal(error.metadata.limit_type, 'requests_per_minute');
+    // The server said 20 seconds, so we must report 20 seconds.
+    assert.equal(error.metadata.retry_after_seconds, 20);
+    // The bug this replaced: "Daily rate limit exceeded" plus a wait until local
+    // midnight, which for an agent meant abandoning a limit that clears at once.
+    assert.doesNotMatch(JSON.stringify(error), /[Dd]aily/);
+    assert.ok(error.retryable, 'a per-minute limit is retryable');
+  } finally { upstream.close(); }
+});
+
+test('a 402 explains the monthly allowance and, when keyless, points at a free key', async () => {
+  const upstream = await recordingUpstream((req, res) => {
+    res.writeHead(402, { 'content-type': 'application/json' });
+    res.end('{"message":"quota"}');
+  });
+  try {
+    const response = await callTool({
+      env: { DEXPAPRIKA_API_BASE_URL: `http://127.0.0.1:${upstream.port}`, DEXPAPRIKA_API_KEY: '' },
+      toolName: 'getNetworks', args: { rationale: RATIONALE },
+    });
+    const { error } = payload(response);
+    assert.equal(error.code, 'DP402_QUOTA_EXHAUSTED');
+    assert.equal(error.metadata.limit_type, 'monthly_credits');
+    assert.equal(error.metadata.using_api_key, false);
+    // Keyless is the one place where pointing at a free key is honest, because a
+    // key genuinely raises this ceiling. It does not raise the per-minute one.
+    assert.match(error.suggestion, /DEXPAPRIKA_API_KEY/);
+  } finally { upstream.close(); }
+});


### PR DESCRIPTION
Wave 1 of #169 (coinpaprika/devrel). Biggest reach of any surface we have, 2,176
installs last month, and the smallest diff, because every call already goes
through one function.

**Keyless is and stays the default.** With nothing configured the outbound
request is what it always was, plus a User-Agent. Nothing starts requiring a key.

### What changed

| | |
|---|---|
| `DEXPAPRIKA_API_KEY` | optional, read from the environment |
| `DEXPAPRIKA_API_BASE_URL` | optional, for Pro customers on api-pro |
| `getKeyStatus` | new tool, answers "is my key actually being used" |
| 429 handling | fixed, see below |
| 402 handling | added |
| User-Agent | added, we sent none at all before |

### The Bearer rule, pinned rather than reviewed

The key is the **entire** `Authorization` value. No `Bearer`, no other scheme
word: the API checksums the raw header and nothing strips a scheme off the front.
This is our most common support failure and it has resurfaced three times in four
months, so `test/http-config.test.js` asserts against five different scheme words
and `test/wire.test.js` re-checks it on the actual outbound request.

The README mentions `Bearer` exactly once, as the warning. Never as an example.

### The 429 handler was actively misleading agents

Worth a look even if the rest is uncontroversial. It reported a **daily** rate
limit and computed the retry time by rounding up to local midnight, ignoring the
`Retry-After` the server sends:

```js
const resetTime = new Date();
resetTime.setHours(24, 0, 0, 0);   // could be ~80,000 seconds away
```

The limit is per-minute and clears in seconds. An agent that believed this would
abandon the task for hours over something that resolves immediately. It now
reports the per-minute limit and honours the server's header, or returns `null`
and says it does not know, rather than inventing a number.

402 had no handler and fell through to a generic message. It now separates the
monthly allowance from the per-minute limit and, when keyless, points at a free
key. **Deliberately not on the 429 path**: a free key raises the monthly
allowance but not the per-minute rate, so suggesting registration at that moment
would be false and the user would find out in five minutes.

### getKeyStatus, and why it needs to exist

On our API you cannot tell from a normal call whether your key works. The data
endpoints ignore an unreadable key and serve the keyless tier with a `200` and
real data, so a wrong header name looks exactly like success while the caller
silently gets nothing for their key. Verified today:

```
api.dexpaprika.com     no header   bad key   X-API-Key
  /networks               200        200       200
  /usage                  200        401       200
                    (plan: keyless)       (plan: keyless)
```

`/usage` is the only endpoint that reports the truth, and the new tool turns it
into an answer with a named cause.

### Testing

37 tests across three files, wired into CI ahead of the existing smoke check on
node 18, 20 and 22.

- **unit** bare-key format vs five scheme words, keyless behaviour, header
  injection through both the key and a hostile MCP client name, length caps, host
  rules
- **retry-after** delta-seconds, HTTP-date, malformed, absent, plus a regression
  guard that the multi-hour value can never return
- **wire** spawns the built server over stdio against a recording origin and
  asserts on the request that actually leaves the process, which is the only
  level that proves the rules are applied and not merely defined

Also run against production: keyless returns 36 networks and reports the keyless
plan, a deliberately wrong key produces the 401 diagnosis.

**One path I could not verify:** a genuine free key end to end, because I do not
have one. Worth someone with a real key running `getKeyStatus` before we publish
2.4.1.