### PR TITLE
fix(getKeyStatus): the rejection diagnosis blames Bearer, which cannot cause it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -743,7 +743,7 @@ server.registerTool(
         plan_reported_by_api: null,
         key_reaching_api: false,
         diagnosis: configured
-          ? 'The key reached the API and was rejected. The most common cause by far is a scheme word: the key must be the entire Authorization value, with no "Bearer" in front. Otherwise check for a truncated paste.'
+          ? 'The key reached the API and was rejected. The most common cause is a scheme word: the key must be the entire Authorization value, so "ApiKey" or "Token" in front of it fails. ("Bearer" is stripped by api.dexpaprika.com and would not cause this.) Otherwise check for a truncated paste.'
           : 'Could not read usage. The server is running keyless, which is the default and needs no key.',
         error: error && typeof error === 'object' && 'error' in error ? error.error : String(error),
       });


### PR DESCRIPTION
`getKeyStatus` is the tool a user reaches for when their key is not working. When the key reaches the API and is rejected, it currently says:

> The most common cause **by far** is a scheme word: the key must be the entire Authorization value, with no "Bearer" in front.

`Bearer` is the one scheme word that cannot produce that 401. `api.dexpaprika.com` strips a case-insensitive `Bearer ` before the checksum:

```
Authorization: api_...          200  {"plan":"free",...}
Authorization: Bearer api_...   200  {"plan":"free",...}
Authorization: bearer api_...   200  {"plan":"free",...}
Authorization: ApiKey api_...   401  {"message":"api key verification has failed"}
Authorization: Token  api_...   401  {"message":"api key verification has failed"}
Authorization: Basic  api_...   401  {"message":"api key verification has failed"}
```

Unique URL per call and `cf-cache-status: BYPASS` on every one, so the response cache does not explain it.

A diagnosis that names the wrong cause is worse than a generic one: someone who did send `Bearer`, read this, and removed it sees no change and stops trusting the tool. It now names `ApiKey` and `Token`, and rules `Bearer` out in a clause.

Behaviour is unchanged. The client still sends the bare key, and `test/http-config.test.js` still asserts the `Authorization` header never grows a scheme word.

Docs side: coinpaprika/dexpaprika-docs#127. Same correction in the four SDK READMEs, the CLI and langchain.

One string. Can ride along with the next release rather than needing one of its own.
