### PR TITLE
README: keyless is 15 requests a minute, not 30

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ const prices = await getTokenMultiPrices({
 
 ## Rate Limits & Performance
 
-- **Free tier**: keyless, no signup, at 30 requests per minute. A free API key raises the monthly quota and unlocks streaming. Pro is $99/month at 300 requests per minute. One request costs one credit; batch endpoints cost one credit per item. Monthly quotas change, so read them here rather than from this page: https://dexpaprika.com/api/pricing
+- **Free tier**: keyless, no signup, at 15 requests per minute. A free API key raises that to 30 requests per minute, raises the monthly quota, and unlocks streaming. Pro is $99/month at 300 requests per minute. One request costs one credit; batch endpoints cost one credit per item. Monthly quotas change, so read them here rather than from this page: https://dexpaprika.com/api/pricing
 - **Data delay**: up to 15 seconds on the free tier, real-time on Pro
 - **Response Time**: 100-500ms for most endpoints (network dependent)
 - **Error Handling**: Structured errors with codes, suggestions, and retry guidance

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ const prices = await getTokenMultiPrices({
 
 ## Rate Limits & Performance
 
-- **Free tier**: keyless, no signup, at 15 requests per minute. A free API key raises that to 30 requests per minute, raises the monthly quota, and unlocks streaming. Pro is $99/month at 300 requests per minute. One request costs one credit; batch endpoints cost one credit per item. Monthly quotas change, so read them here rather than from this page: https://dexpaprika.com/api/pricing
+- **Free tier**: keyless, no signup, at 15 requests per minute. A free API key raises that to 30 requests per minute, raises the monthly quota, and unlocks streaming: register at https://console.dexpaprika.com. Pro is $99/month at 300 requests per minute. One request costs one credit; batch endpoints cost one credit per item. Full docs at https://docs.dexpaprika.com. Monthly quotas change, so read them here rather than from this page: https://dexpaprika.com/api/pricing
 - **Data delay**: up to 15 seconds on the free tier, real-time on Pro
 - **Response Time**: 100-500ms for most endpoints (network dependent)
 - **Error Handling**: Structured errors with codes, suggestions, and retry guidance

--- a/src/index.js
+++ b/src/index.js
@@ -544,6 +544,7 @@ const OUTPUT_SCHEMAS = {
       free_key_requests_per_minute: z.number(),
       free_tier_max_data_delay_seconds: z.number(),
       limits_url: z.string().describe('Live source for the quota and rate figures above, which change.'),
+      console_url: z.string().describe('Where to register a free API key, which doubles the per-minute limit.'),
       pricing_url: z.string(),
     }).passthrough(),
     network_synonyms: z.record(z.string(), z.array(z.string())).describe('Canonical network id -> common alternates an agent might try.'),
@@ -655,6 +656,7 @@ function buildCapabilitiesDocument() {
       free_key_requests_per_minute: 30,            // with a free API key
       free_tier_max_data_delay_seconds: 15,        // real-time is the Pro figure
       limits_url: 'https://docs.dexpaprika.com/knowledge-base/rate-limits',
+      console_url: 'https://console.dexpaprika.com',
       pricing_url: 'https://dexpaprika.com/api/pricing',
     },
     network_synonyms: NETWORK_SYNONYMS,

--- a/src/index.js
+++ b/src/index.js
@@ -244,9 +244,12 @@ function parseAPIError(status, statusText, endpoint, body, responseHeaders) {
         // Null rather than invented: a made-up number is what produced the
         // wait-until-midnight advice this replaces.
         retry_after_seconds: retryAfterSeconds,
-        // Deliberately no "register for more" hint here. A free API key raises
-        // the monthly allowance and opens streaming, but it does NOT raise the
-        // per-minute limit, so suggesting it at this moment would be false.
+        // This hint used to be withheld, on the reasoning that a free key raises
+        // the monthly allowance and opens streaming but does NOT raise the
+        // per-minute limit. That reasoning was built on the wrong number. A free
+        // key doubles the per-minute limit, 15 to 30, so on a per-minute 429 it
+        // is the most useful thing we can say.
+        raise_the_limit: 'A free API key doubles the per-minute limit from 15 to 30. Register at https://console.dexpaprika.com',
         reduce_request_count: 'Batch up to 10 tokens per call with getTokenMultiPrices, or stream instead of polling.',
       },
     );
@@ -538,6 +541,7 @@ const OUTPUT_SCHEMAS = {
       free_tier_credits_per_month: z.number(),
       free_key_credits_per_month: z.number(),
       free_tier_requests_per_minute: z.number(),
+      free_key_requests_per_minute: z.number(),
       free_tier_max_data_delay_seconds: z.number(),
       limits_url: z.string().describe('Live source for the quota and rate figures above, which change.'),
       pricing_url: z.string(),
@@ -647,7 +651,8 @@ function buildCapabilitiesDocument() {
       // hard-coded here.
       free_tier_credits_per_month: 50_000,         // keyless, per IP
       free_key_credits_per_month: 300_000,         // with a free API key
-      free_tier_requests_per_minute: 30,           // same on both free tiers
+      free_tier_requests_per_minute: 15,           // keyless, per IP
+      free_key_requests_per_minute: 30,            // with a free API key
       free_tier_max_data_delay_seconds: 15,        // real-time is the Pro figure
       limits_url: 'https://docs.dexpaprika.com/knowledge-base/rate-limits',
       pricing_url: 'https://dexpaprika.com/api/pricing',

--- a/test/capabilities.test.js
+++ b/test/capabilities.test.js
@@ -68,8 +68,21 @@ test('the advertised limits carry a live source, because they change', async () 
   assert.notEqual(stats.free_tier_credits_per_month, 200_000);
   assert.notEqual(stats.free_key_credits_per_month, 500_000);
 
-  // Registering raises the monthly allowance and nothing else. If this ever
-  // stops being true the 429 copy has to change with it, so pin it.
+  // Registering raises the monthly allowance AND the per-minute rate. The old
+  // version of this test pinned free_tier_requests_per_minute to 30 with a
+  // comment saying registering "raises the monthly allowance and nothing else",
+  // and predicted that if that ever stopped being true the 429 copy would have
+  // to change with it. It was never true: keyless has always been 15. So the
+  // test was pinning the bug, and the 429 copy did have to change.
   assert.ok(stats.free_key_credits_per_month > stats.free_tier_credits_per_month);
-  assert.equal(stats.free_tier_requests_per_minute, 30);
+  assert.equal(stats.free_tier_requests_per_minute, 15);
+  assert.equal(stats.free_key_requests_per_minute, 30);
+  assert.ok(
+    stats.free_key_requests_per_minute > stats.free_tier_requests_per_minute,
+    'a free key must buy real per-minute headroom, otherwise the 429 hint is false',
+  );
+
+  // Telling an agent a key doubles its limit is only useful with somewhere to
+  // get one.
+  assert.equal(stats.console_url, 'https://console.dexpaprika.com');
 });


### PR DESCRIPTION
One line. The free-tier bullet states a single per-minute figure and attaches it
to keyless callers:

> **Free tier**: keyless, no signup, at 30 requests per minute.

There are two figures. **Keyless is 15**, **a free key is 30**. Measured three
times, cold and cache-busted: 15 consecutive 200s, first 429 on request 16.
`dexpaprika.com/api/pricing` already states it correctly.

The line now reads:

> **Free tier**: keyless, no signup, at 15 requests per minute. A free API key
> raises that to 30 requests per minute, raises the monthly quota, and unlocks
> streaming.

## Reach

Glama renders this README verbatim on our listing, so the wrong number is
currently on a third-party directory page with its own search traffic. Merging
this clears it on Glama's next crawl, with nothing else to do there.

npm serves the README from the published tarball, so **npmjs.com will keep
showing 30 until the next release**. No code changed here, so this can ride
along with whatever ships next rather than justifying a release of its own.



---

## It was not only the README

After opening this I grepped the source, and `src/index.js` carries the same
wrong number in the place that matters more:

```js
free_tier_requests_per_minute: 30,           // same on both free tiers
```

That is the `getCapabilities` document, which is the first thing an agent reads
to learn how hard it may hit the API. It now reports **15 keyless and 30 with a
free key**, and the Zod schema accepts the new field.

**The behavioural half.** The 429 handler deliberately withheld a "register for a
free key" hint, with a comment explaining that a key raises the monthly allowance
and opens streaming but does *not* raise the per-minute limit, so offering it on
a 429 would be false. That reasoning is sound if both free tiers are 30. With the
real numbers it inverts: a free key **doubles** the per-minute limit, so on a
per-minute 429 it is the most useful thing we can say, and we were suppressing
it. The handler now returns it.

**Verified by driving the server, not by reading it.** I ran the real server over
stdio, completed the MCP handshake and called `getCapabilities`: it returns 15,
30, and the console, rate-limits and pricing URLs, with no error.

I first wrote that `npm test` was the only check here. That was wrong: `npm test`
only starts the process, but `npm run test:unit` is a real 40-test suite and CI
runs it. It caught this change, correctly, because `capabilities.test.js` pinned
`free_tier_requests_per_minute === 30`. That test now pins the true invariant
instead, including that a free key must buy real per-minute headroom, since the
429 hint is false otherwise. 40/40 green on node 18, 20 and 22.

Because this changes shipped behaviour rather than only the README, it does now
justify a release of its own.

